### PR TITLE
Box_Headers: fix incorrect "missing CadQuery" message

### DIFF
--- a/cadquery/FCAD_script_generator/Box_Headers/main_generator.py
+++ b/cadquery/FCAD_script_generator/Box_Headers/main_generator.py
@@ -76,6 +76,7 @@ pins_color = shaderColors.named_colors[pins_color_key].getDiffuseFloat()
 # maui start
 import FreeCAD, Draft, FreeCADGui
 import ImportGui
+import FreeCADGui as Gui
 
 if FreeCAD.GuiUp:
     from PySide import QtCore, QtGui


### PR DESCRIPTION
Running Box_Headers `main_generator.py` gives "missing CadQuery 0.3.0 or later Module!" error message.

Fixed by adding `import FreeCADGui as Gui` (as seen in other generators).
