### PR TITLE
Housings_SON: fix missing EPs, chamfers

### DIFF
--- a/cadquery/FCAD_script_generator/QFN_packages/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/QFN_packages/cq_parameters.py
@@ -2841,7 +2841,7 @@ kicad_naming_params_qfn = {
         rotation = -90, # rotation if required
         dest_dir_prefix = '../Housings_SON.3dshapes/'
         ),
-    'Texas_S-PVSON-N10': Params( # from http://www.ti.com/lit/ml/mpds117k/mpds117k.pdf
+    'Texas_S-PVSON-N10': Params( # from http://www.ti.com/lit/ds/symlink/lm5165.pdf
         c = 0.2,        # pin thickness, body center part height
 #        K=0.2,          # Fillet radius for pin edges
         L = 0.4,        # pin top flat part length (including fillet radius)
@@ -2850,7 +2850,7 @@ kicad_naming_params_qfn = {
         fp_d = 0.1,     # first pin indicator distance from edge
         fp_z = 0.01,     # first pin indicator depth
         ef = 0.0, # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
-        cce = 0.01,      #0.45 chamfer of the epad 1st pin corner
+        cce = 0.3,      #0.45 chamfer of the epad 1st pin corner
         D = 3.0,       # body overall length
         E = 3.0,       # body overall width
         A1 = 0.02,  # body-board separation  maui to check

--- a/cadquery/FCAD_script_generator/QFN_packages/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/QFN_packages/cq_parameters.py
@@ -2867,7 +2867,7 @@ kicad_naming_params_qfn = {
         rotation = -90, # rotation if required
         dest_dir_prefix = '../Housings_SON.3dshapes/'
         ),
-    'Texas_S-PVSON-N8': Params( # from http://www.ti.com/lit/ml/mpds118j/mpds118j.pdf
+    'Texas_S-PVSON-N8': Params( # from http://www.ti.com/lit/ds/symlink/opa2333.pdf
         c = 0.2,        # pin thickness, body center part height
 #        K=0.2,          # Fillet radius for pin edges
         L = 0.4,        # pin top flat part length (including fillet radius)
@@ -2876,7 +2876,7 @@ kicad_naming_params_qfn = {
         fp_d = 0.1,     # first pin indicator distance from edge
         fp_z = 0.01,     # first pin indicator depth
         ef = 0.0, # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
-        cce = 0.01,      #0.45 chamfer of the epad 1st pin corner
+        cce = 0.3,      #0.45 chamfer of the epad 1st pin corner
         D = 3.0,       # body overall length
         E = 3.0,       # body overall width
         A1 = 0.02,  # body-board separation  maui to check
@@ -2887,7 +2887,7 @@ kicad_naming_params_qfn = {
         ps = 'rounded',   # rounded pads
         npx = 4,  # number of pins along X axis (width)
         npy = 0,  # number of pins along y axis (length)
-        epad = None, # e Pad #epad = None, # e Pad
+        epad = (2.4, 1.65), # e Pad #epad = None, # e Pad
         excluded_pins = None, #no pin excluded
         modelName = 'Texas_S-PVSON-N8', #modelName
         rotation = -90, # rotation if required


### PR DESCRIPTION
I spotted a couple of incorrect datasheets used in my earlier PR (https://github.com/easyw/kicad-3d-models-in-freecad/pull/69).  With these fixed, two models needed small changes.

I have updated these models in the related PRs:
https://github.com/KiCad/kicad-library/pull/1305
https://github.com/KiCad/packages3D/pull/64