### PR TITLE
Added pin 22 and 24

### DIFF
--- a/cadquery/FCAD_script_generator/Molex_90325/cq_models/conn_molex_90325_params.py
+++ b/cadquery/FCAD_script_generator/Molex_90325/cq_models/conn_molex_90325_params.py
@@ -30,6 +30,8 @@ all_params = {								# Molex part number
     'Molex_Picoflex_90325_16' : generate_params(16, "Picoflex_90325", 1.27),
     'Molex_Picoflex_90325_18' : generate_params(18, "Picoflex_90325", 1.27),
     'Molex_Picoflex_90325_20' : generate_params(20, "Picoflex_90325", 1.27),
+    'Molex_Picoflex_90325_22' : generate_params(22, "Picoflex_90325", 1.27),
+    'Molex_Picoflex_90325_24' : generate_params(24, "Picoflex_90325", 1.27),
     'Molex_Picoflex_90325_26' : generate_params(26, "Picoflex_90325", 1.27)	
 }
 


### PR DESCRIPTION
Hi

Another change, 
Added pin set 22 and 24, 

Apparently they do not agree on Molex if they make pin 22 and pin24 

This one says it is so
http://www.molex.com/pdm_docs/sd/903250004_sd.pdf

But this one says it does not 
https://www.elfa.se/Web/Downloads/52/02/04355202.pdf

So I added them anyway
