### PR TITLE
Added DFN-6-1EP_3x3mm_Pitch1mm

### DIFF
--- a/cadquery/FCAD_script_generator/QFN_packages/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/QFN_packages/cq_parameters.py
@@ -603,6 +603,32 @@ kicad_naming_params_qfn = {
         rotation = -90, # rotation if required
         dest_dir_prefix = '../Housings_DFN_QFN.3dshapes/'
         ),
+    'DFN-6-1EP_3x3mm_Pitch1mm': Params( # from https://www.silabs.com/documents/public/data-sheets/Si7020-A20.pdf
+        c = 0.2,        # pin thickness, body center part height
+#        K=0.2,          # Fillet radius for pin edges
+        L = 0.5,        # pin top flat part length (including fillet radius)
+        fp_s = True,     # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.5,     # first pin indicator radius
+        fp_d = 0.1,     # first pin indicator distance from edge
+        fp_z = 0.01,     # first pin indicator depth
+        ef = 0.0, # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        cce = 0.2,      #0.45 chamfer of the epad 1st pin corner
+        D = 3.0,       # body overall length
+        E = 3.0,       # body overall width
+        A1 = 0.02,  # body-board separation  maui to check
+        A2 = 0.85,  # body height
+        b = 0.35,  # pin width
+        e = 1.00,  # pin (center-to-center) distance
+        m = 0.0,  # margin between pins and body  
+        ps = 'square',   # square pads
+        npx = 3,  # number of pins along X axis (width)
+        npy = 0,  # number of pins along y axis (length)
+        epad = (2.0,1.2), # e Pad #epad = None, # e Pad
+        excluded_pins = None, #no pin excluded
+        modelName = 'DFN-6-1EP_3x3mm_Pitch1mm', #modelName
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Housings_DFN_QFN.3dshapes/'
+        ),
     'DFN-8_2x2mm_Pitch0.5mm': Params( # from https://www.onsemi.com/pub/Collateral/506AQ.PDF
         c = 0.2,        # pin thickness, body center part height
 #        K=0.2,          # Fillet radius for pin edges


### PR DESCRIPTION
This is push of 3D models of the DFN-6-1EP_3x3mm_Pitch1mm

Used by this one
https://www.silabs.com/documents/public/data-sheets/Si7020-A20.pdf

kicad-library 3D model push
https://github.com/KiCad/kicad-library/pull/1659

KiCad/Housings_DFN_QFN.pretty push
https://github.com/KiCad/Housings_DFN_QFN.pretty/pull/63

KiCad/kicad-packages3D
https://github.com/KiCad/kicad-packages3D/pull/137

easyw/kicad-3d-models-in-freecad
https://github.com/easyw/kicad-3d-models-in-freecad/pull/108

![bild](https://user-images.githubusercontent.com/25547797/30784391-9ffb6174-a154-11e7-952d-1c9a0dc3aa8c.png)

![bild](https://user-images.githubusercontent.com/25547797/30784392-a444a07e-a154-11e7-842c-8d0aec5783c2.png)

![bild](https://user-images.githubusercontent.com/25547797/30784393-a84d7560-a154-11e7-8557-68d2b9d58094.png)
