### PR TITLE
Added SO-20_12.8x7.5mm_Pitch1.27mm

### DIFF
--- a/cadquery/FCAD_script_generator/GW_QFP_SOIC_SSOP_TSSOP_SOT/cq_parameters_soic.py
+++ b/cadquery/FCAD_script_generator/GW_QFP_SOIC_SSOP_TSSOP_SOT/cq_parameters_soic.py
@@ -199,7 +199,36 @@ kicad_naming_params_soic = {
         rotation = -90,   # rotation if required
         dest_dir_prefix = 'SOIC'
         ),
-    'SOIC-8_3.9x4.9mm_Pitch1.27mm': Params( # from http://www.ti.com/lit/ml/msoi002j/msoi002j.pdf
+	'SO-20_12.8x7.5mm_Pitch1.27mm': Params( # SA605 https://www.nxp.com/docs/en/data-sheet/SA605.pdf
+        the = 9.0,      # body angle in degrees
+        tb_s = 0.15,    # top part of body is that much smaller
+        c = 0.1,        # pin thickness, body center part height
+        R1 = 0.1,       # pin upper corner, inner radius
+        R2 = 0.1,       # pin lower corner, inner radius
+        S = 0.30,       # pin top flat part length (excluding corner arc)
+#        L = 0.65,      # pin bottom flat part length (including corner arc)
+        fp_s = True,    # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.6,     # first pin indicator radius
+        fp_d = 0.05,    # first pin indicator distance from edge
+        fp_z = 0.05,    # first pin indicator depth
+        ef = 0.0,       # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,		#0.45 chamfer of the 1st pin corner
+        D1 = 12.8,      # body length
+        E1 = 7.5,       # body width
+        E = 10.325,     # body overall width
+        A1 = 0.2,       # body-board separation
+        A2 = 2.35,      # body height
+        b = 0.425,      # pin width
+        e = 1.27,       # pin (center-to-center) distance
+        npx = 10,        # number of pins along X axis (width)
+        npy = 0,        # number of pins along y axis (length)
+        epad = None,    # e Pad
+        excluded_pins = None, #no pin excluded
+        modelName = 'SO-20_12.8x7.5mm_Pitch1.27mm', #modelName
+        rotation = -90,   # rotation if required
+        dest_dir_prefix = 'SOIC'
+        ),
+        'SOIC-8_3.9x4.9mm_Pitch1.27mm': Params( # from http://www.ti.com/lit/ml/msoi002j/msoi002j.pdf
         the = 9.0,      # body angle in degrees
         tb_s = 0.15,    # top part of body is that much smaller
         c = 0.2,        # pin thickness, body center part height


### PR DESCRIPTION
This is foot print SO-20_12.8x7.5mm_Pitch1.27mm
It is used by SA605D
https://www.nxp.com/docs/en/data-sheet/SA605.pdf

kicad-library
https://github.com/KiCad/kicad-library/pull/1706

Housings_SOIC.pretty
https://github.com/KiCad/kicad-packages3D/pull/141

kicad-packages3D
https://github.com/KiCad/kicad-packages3D/pull/141

kicad-3d-models-in-freecad
https://github.com/easyw/kicad-3d-models-in-freecad/pull/110

![bild](https://user-images.githubusercontent.com/25547797/31310362-431b0854-ab97-11e7-9ec6-510c860eab38.png)
