### PR TITLE
Shift picoblade models to match newly shifted footprints

### DIFF
--- a/cadquery/FCAD_script_generator/molex/cq_models/conn_molex_picoblade_53261.py
+++ b/cadquery/FCAD_script_generator/molex/cq_models/conn_molex_picoblade_53261.py
@@ -89,7 +89,9 @@ mounting_pad_size_y = 3.0
 rel_pad_y_outside_edge = 5.2
 rel_pad_y_inside_edge = 3.6
 
-y_origin_from_mountpad = -rel_pad_y_outside_edge/2 + mounting_pad_size_y/2
+# amount to shift y position of center for pick-and-place (positive -> shift whole footprint up)
+center_shift_y = 1
+y_origin_from_mountpad = -rel_pad_y_outside_edge/2 + mounting_pad_size_y/2 + center_shift_y
 print(y_origin_from_mountpad)
 
 mount_pin_back_to_body_back = 1

--- a/cadquery/FCAD_script_generator/molex/cq_models/conn_molex_picoblade_53398.py
+++ b/cadquery/FCAD_script_generator/molex/cq_models/conn_molex_picoblade_53398.py
@@ -89,7 +89,9 @@ mounting_pad_size_y = 3.0
 rel_pad_y_outside_edge = 4.9
 rel_pad_y_inside_edge = 3.6
 
-y_origin_from_mountpad = -rel_pad_y_outside_edge/2 + mounting_pad_size_y/2
+# amount to shift y position of center for pick-and-place (positive -> shift whole footprint up)
+center_shift_y = -0.55
+y_origin_from_mountpad = -rel_pad_y_outside_edge/2 + mounting_pad_size_y/2 + center_shift_y
 
 
 mount_pin_lenght = 1.7


### PR DESCRIPTION
This corresponds with https://github.com/pointhi/kicad-footprint-generator/pull/94

This is necessary to bring the picoblade footprints in line with KLC F6.2. This needs to be checked for all other connectors as well.