### PR TITLE
Correct picoblade 53261 centers

### DIFF
--- a/cadquery/FCAD_script_generator/molex/cq_models/conn_molex_picoblade_53261.py
+++ b/cadquery/FCAD_script_generator/molex/cq_models/conn_molex_picoblade_53261.py
@@ -90,7 +90,7 @@ rel_pad_y_outside_edge = 5.2
 rel_pad_y_inside_edge = 3.6
 
 # amount to shift y position of center for pick-and-place (positive -> shift whole footprint up)
-center_shift_y = 1
+center_shift_y = 0.6
 y_origin_from_mountpad = -rel_pad_y_outside_edge/2 + mounting_pad_size_y/2 + center_shift_y
 print(y_origin_from_mountpad)
 


### PR DESCRIPTION
Accidentally placed these in the wrong spot earlier. Fixed now.