### PR TITLE
Make exceptions more precise and add output where it was missing.

### DIFF
--- a/cadquery/FCAD_script_generator/_tools/add_license.py
+++ b/cadquery/FCAD_script_generator/_tools/add_license.py
@@ -67,7 +67,7 @@ LIST_int_license = ["Copyright (C) "+datetime.now().strftime("%Y")+", " + STR_in
 
 
 def say(*arg):
-    FreeCAD.Console.PrintMessage(" ".join(map(str,arg)) + "\r\n")
+    FreeCAD.Console.PrintMessage(" ".join(map(str,arg)) + "\n")
 
 def FNCT_modify_step(PMBL_stepfile,
                      DICT_positions,
@@ -142,7 +142,8 @@ def FNCT_modify_step(PMBL_stepfile,
 
 
 def addLicenseToStep(FLDR_toStepFiles, FNME_stepfile, LIST_license, STR_licAuthor, STR_licEmail="", STR_licOrgSys="", STR_licOrg="",STR_licPreProc=""):
-    if os.path.isfile(FLDR_toStepFiles + os.sep + FNME_stepfile): # test if folder or file..
+    filepath = FLDR_toStepFiles + os.sep + FNME_stepfile
+    if os.path.isfile(filepath): # test if folder or file..
         fname, ext=os.path.splitext(FNME_stepfile)
         if LIST_license[0] == "":
             LIST_license=list(LIST_int_license)
@@ -150,9 +151,11 @@ def addLicenseToStep(FLDR_toStepFiles, FNME_stepfile, LIST_license, STR_licAutho
         if ext == ".stp" or ext == ".step": # test if step file
             #say("Starting of licensing\n")
             try:
-                HDLR_stepfile = open(FLDR_toStepFiles + os.sep  + FNME_stepfile, 'r') # open
-            except:
-                say("broken_2")
+                HDLR_stepfile = open(filepath, 'r') # open
+            except Exception as exception:
+                FreeCAD.Console.PrintError("Add License: Can't open step file for read access\n")
+                FreeCAD.Console.PrintError("{:s}\n".format(exception))
+                return
 
             HDLR_stepfile.seek(0)
             PMBL_stepfile = HDLR_stepfile.readlines()
@@ -189,17 +192,22 @@ def addLicenseToStep(FLDR_toStepFiles, FNME_stepfile, LIST_license, STR_licAutho
 
             # overwrite step file
             try:
-                HDLR_stepfile_w = open(FLDR_toStepFiles + os.sep  + FNME_stepfile, 'w') # open
-            except:
-                say("broken_3")
-            else:
-                # overwrite with new preamble
-                for line in LIST_PMBL:
-                    HDLR_stepfile_w.write(line + "\n")
-                # add old data section
-                for line in PMBL_stepfile[(DICT_positions["A"]-1):]:
-                    HDLR_stepfile_w.write(line.strip() + "\n")
-                HDLR_stepfile_w.close()
-    say ("License addition successful")
+                HDLR_stepfile_w = open(filepath, 'w') # open
+            except Exception as exception:
+                FreeCAD.Console.PrintError("Add License: Can't open step file for write access\n")
+                FreeCAD.Console.PrintError("{:s}\n".format(exception))
+                return
 
+            # overwrite with new preamble
+            for line in LIST_PMBL:
+                HDLR_stepfile_w.write(line + "\n")
+            # add old data section
+            for line in PMBL_stepfile[(DICT_positions["A"]-1):]:
+                HDLR_stepfile_w.write(line.strip() + "\n")
+            HDLR_stepfile_w.close()
+            say ("License addition successful")
+        else:
+            FreeCAD.Console.PrintWarning("Add License: File has wrong file extension: {:s}".format(FNME_stepfile))
+    else:
+        FreeCAD.Console.PrintWarning("Add License: Path does not exist: {:s}".format(filepath))
 ###

--- a/cadquery/FCAD_script_generator/_tools/cq_cad_tools.py
+++ b/cadquery/FCAD_script_generator/_tools/cq_cad_tools.py
@@ -90,7 +90,7 @@ def checkBOP(shape):
     try:
         shape.check(True)
         return True
-    except:
+    except Exception:
         return sys.exc_info()[1] #ValueError #sys.exc_info() #False
 ##
 
@@ -110,8 +110,9 @@ def getListOfNumbers(string):
                 b = int(b)
                 if a > 0 and b > a:
                     numbers = [i for i in range(a,b+1)]
-            except:
-                pass
+            except Exception as exp:
+                FreeCAD.Console.PrintWarning("Error in getListOfNumbers range case:")
+                FreeCAD.Console.PrintWarning('{:s}\n'.format(exp))
 
     elif ',' in string:
         #Now, split by comma
@@ -120,14 +121,16 @@ def getListOfNumbers(string):
         for s in ss:
             try:
                 numbers += [int(s)]
-            except:
-                pass
+            except Exception as exp:
+                FreeCAD.Console.PrintWarning("Error in getListOfNumbers list case:")
+                FreeCAD.Console.PrintWarning('{:s}\n'.format(exp))
 
     else:
         try:
             numbers = [int(string)]
-        except:
-            numbers = []
+        except Exception as exp:
+            FreeCAD.Console.PrintWarning("Error in getListOfNumbers single number case:")
+            FreeCAD.Console.PrintWarning('{:s}\n'.format(exp))
 
     return numbers
 
@@ -547,13 +550,15 @@ def saveFCdoc(App, Gui, doc, modelName,dir, saving = True):
     App.getDocument(doc.Name).save()
     try:
         os.remove(outdir+os.sep+modelName+'.FCStd1') #removing backup file
-    except:
-        pass
+    except Exception as exp:
+        FreeCAD.Console.PrintWarning("Error while trying to remove backup file in saveFCdoc:")
+        FreeCAD.Console.PrintWarning('{:s}\n'.format(exp))
     if saving == False:
         try:
             os.remove(outdir+os.sep+modelName+'.FCStd') #removing project file
-        except:
-            pass
+        except Exception as exp:
+            FreeCAD.Console.PrintWarning("Error while trying to remove file in saveFCdoc (with save == False):")
+            FreeCAD.Console.PrintWarning('{:s}\n'.format(exp))
     else:
         FreeCAD.Console.PrintMessage(outdir+os.sep+modelName+'.FCStd saved\n')
     return 0


### PR DESCRIPTION
I added exception handlers to all execptions that simply had a pass statement in them.
(The one in the step license script would have resulted in a null pointer exception or accessed before assigned if it would ever have been triggered.)
Also added warning text if the step file does not exist or if a wrong extension has been discovered. (previously the script told the user via the console that everything is ok even if it failed to add a license.)

`except:` without specifying any exception class would also catch system internal exceptions (exit, and kill). To catch all (user) exceptions, `except Exception:` should be used.