### PR TITLE
Add 18-pin variant of SSOP used by Toshiba.

### DIFF
--- a/cadquery/FCAD_script_generator/GW_QFP_SOIC_SSOP_TSSOP_SOT/cq_parameters_ssop.py
+++ b/cadquery/FCAD_script_generator/GW_QFP_SOIC_SSOP_TSSOP_SOT/cq_parameters_ssop.py
@@ -808,6 +808,35 @@ part_params = {
         modelName = 'SSOP-16_5.3x6.2mm_P0.65mm',
         rotation = -90,       # rotation if required
         ),
+    'SSOP-18_4.4x6.5mm_Pitch0.65mm': Params( # from https://toshiba.semicon-storage.com/us/design-support/package/detail.SSOP18-P-225-0.65.html
+        the = 12.0,           # body angle in degrees
+        tb_s = 0.15,          # top part of body is that much smaller
+        c = 0.15,             # pin thickness, body center part height
+        R1 = 0.1,             # pin upper corner, inner radius
+        R2 = 0.1,             # pin lower corner, inner radius
+        S = 0.2,              # pin top flat part length (excluding corner arc)
+#        L = 0.64,            # pin bottom flat part length (including corner arc)
+        fp_s = True,     # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.5,           # first pin indicator radius
+        fp_d = 0.2,           # first pin indicator distance from edge
+        fp_z = 0.1,           # first pin indicator depth
+        ef = 0, # 0.05,       # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,           # 0.45 chamfer of the 1st pin corner
+        D1 = 6.5,             # body length
+        E1 = 4.4,             # body width
+        E = 6.4,              # body overall width  E=E1+2*(S+L+c)
+        A1 = 0.1,             # body-board separation
+        A2 = 1.3,             # body height
+        b = 0.24,             # pin width
+        e = 0.65,             # pin (center-to-center) distance
+        npx = 9,              # number of pins along X axis (width)
+        npy = 0,              # number of pins along y axis (length)
+        epad = None,          # ePad
+        excluded_pins = None, # no pin excluded
+        old_modelName = 'SSOP-18_4.4x6.5mm_Pitch0.65mm',
+        modelName = 'SSOP-18_4.4x6.5mm_P0.65mm',
+        rotation = -90,       # rotation if required
+        ),
     'SSOP-20_4.4x6.5mm_Pitch0.65mm': Params( # from http://www.onsemi.com/pub/Collateral/565AM.PDF
         the = 12.0,           # body angle in degrees
         tb_s = 0.15,          # top part of body is that much smaller


### PR DESCRIPTION
This is a slight modification of the existing SSOP-20 model
parameters, with only two pins removed and the pin width adjusted.

Reference is the Toshiba package documentation at
https://toshiba.semicon-storage.com/us/design-support/package/detail.SSOP18-P-225-0.65.html

The resulting STEP and WRL files have been proposed for addition to the KiCAD library at https://github.com/KiCad/kicad-packages3D/pull/320