### PR TITLE
Add exception to import Gui.Command

### DIFF
--- a/cadquery/FCAD_script_generator/QFN_packages/main_generator.py
+++ b/cadquery/FCAD_script_generator/QFN_packages/main_generator.py
@@ -106,8 +106,12 @@ from cq_cad_tools import FuseObjs_wColors, GetListOfObjects, restore_Main_Tools,
  CutObjs_wColors, checkRequirements
 
 try:
-    # Gui.SendMsgToActiveView("Run")
     from Gui.Command import *
+except:
+    print('cannot import Gui.Command')
+
+try:
+    # Gui.SendMsgToActiveView("Run")
     Gui.activateWorkbench("CadQueryWorkbench")
     import cadquery as cq
     from Helpers import show


### PR DESCRIPTION
Thanks for sharing useful scripts.
`from Gui.Command import *` caused error on my environment so I add exception about that.

My environment:

Name | Version
--- | ---
OS | Ubuntu18.04
FreeCAD | 0.17
CadQuery | 1.2.0


Thank you.