### PR TITLE
Added 63 soic 3D models and the creator script

### DIFF
--- a/cadquery/FCAD_script_generator/GW_QFP_SOIC_SSOP_TSSOP_SOT/FindMissingSOIC3DModels.py
+++ b/cadquery/FCAD_script_generator/GW_QFP_SOIC_SSOP_TSSOP_SOT/FindMissingSOIC3DModels.py
@@ -1,0 +1,652 @@
+#
+#
+# Auto create SON 3D models     version 1.0
+#
+# Script to scan SON foot print files and create 3D model paramters for those 3D models that 
+# is missing in \Package_SON.3dshapes
+#
+# This script scan all the foot print files , extract the 3D models file name 
+# and check if the specified 3D model exists, if not, the script will create 
+# the paramters for the 3D model in a cq_paramter.py file style.
+# 
+# It will assume different height of the package depedning on the body size
+# It will assume the distance between the PCB and the body to 0.1 mm
+#
+# The script will use two different list, ExcludeModels and SpecialModels
+#
+# ExcludeModels list
+# If a foot print file name is in the ExcludeModels list it will be ignored 
+# For example the model is to complicated and need to be hand made or missing information 
+# so the data sheet nmust be consulted manually 
+#
+# SpecialModels list
+# If a 3D model name is in the SpecialModels list it will created with the paramters given 
+# in the list regardless what it says in the foot print file
+# For example the model is to complicated and need to be hand made or missing information 
+# so the data sheet nmust be consulted manually 
+#
+# It will scan the FP file to find the desired name of the 3D model name
+# It will scan the foot print file name to exctract body size, pad distance and, if present, 
+# the epad size.
+#
+# The script will create two files MakeFindMissingXXX3DModels.sh and MissingXXX3DModels.txt
+#
+# MissingXXX3DModels.txt
+# This file contain the content that should be appended to the ordinary cq_paramets.py file
+#
+# MakeFindMissingXXX3DModels.sh
+# This batch file contain one line for each missing model, it will start FreeCad 
+# with main_generator.py and the missing model as an argument.
+#
+# How to use this script
+# 1)
+# Execute this script like this 
+# python FindMissingXXX3DModels.py
+# 
+# 2)
+# append the content in MissingXXX3DModels.txt to cq_paramets.py
+#
+# 3)
+# execute the MakeFindMissingXXXDModels.sh so all the 3D models is created with help of FreeCad
+# ./MakeFindMissingXXX3DModels.sh
+#
+
+import sys
+import math
+import os
+import subprocess 
+import time
+import datetime
+from datetime import datetime as dt
+import re
+from pathlib import Path
+
+DefaultA1 = 0.1
+DefaultA =  1.0
+Defaultm =  0.0
+Defaultb =  0.2
+
+
+DefaultDestDirPrefix =  "../Package_SON.3dshapes/"
+
+
+#
+# the path to foot print file directory in relation to where this script is placed
+#
+FPDir = '../kicad-footprints/Package_SO.pretty'
+#
+# the path to foot print file directory in relation to where this script is placed
+#
+ModelDir = '../kicad-footprints/Package_SO.3dshapes'
+
+#
+# The name of the result files
+#
+ResultFile = 'MissingSO3DModels.txt'
+MakeAllfile = 'MakeFindMissingSO3DModels.sh'
+#
+# The path to FreeCad, this path will be used in the MakeFindMissingXXX3DModels.sh script
+#
+FreeCadExe = '/c/users/stefan/Downloads/FreeCAD_0.17.11223_x64_dev_win/FreeCAD_0.17.11223_x64_dev_win/bin/FreeCAD.exe'
+MainGenerator = 'main_generator.py'
+
+
+MissingModels = []
+
+#
+# If a foot print file name is in the ExcludeModels list it will not be created
+#
+ExcludeModels =[
+#                    'Infineon_PQFN-22-15-4EP_6x5mm_P0.65mm.kicad_mod', 
+                    'Diodes_PSOP-8.kicad_mod', 
+                    'HSOP-20-1EP_11.0x15.9mm_P1.27mm_SlugDown.kicad_mod',
+                    'HSOP-20-1EP_11.0x15.9mm_P1.27mm_SlugDown_ThermalVias.kicad_mod',
+                    'HSOP-20-1EP_11.0x15.9mm_P1.27mm_SlugUp.kicad_mod',
+                    'HSOP-36-1EP_11.0x15.9mm_P0.65mm_SlugDown.kicad_mod',
+                    'HSOP-36-1EP_11.0x15.9mm_P0.65mm_SlugDown_ThermalVias.kicad_mod',
+                    'Infineon_PG-DSO-12-11.kicad_mod',
+                    'Infineon_PG-DSO-12-11_ThermalVias.kicad_mod',
+                    'Infineon_PG-DSO-12-9.kicad_mod',
+                    'Infineon_PG-DSO-12-9_ThermalVias.kicad_mod',
+                    'Infineon_PG-DSO-20-30.kicad_mod',
+                    'Infineon_PG-DSO-20-30_ThermalVias.kicad_mod',
+                    'Infineon_PG-DSO-20-32.kicad_mod',
+                    'Infineon_PG-DSO-8-43.kicad_mod',
+                    'Infineon_PG-TSDSO-14-22.kicad_mod',
+                    'Mini-Circuits_CD541_H2.08mm.kicad_mod',
+                    'Mini-Circuits_CD542_H2.84mm.kicad_mod',
+                    'Mini-Circuits_CD636_H4.11mm.kicad_mod',
+                    'Mini-Circuits_CD637_H5.23mm.kicad_mod',
+                    'Vishay_PowerPAK_1212-8_Single.kicad_mod', 
+                    'Zetex_SM8.kicad_mod',
+                    'PowerPAK_SO-8_Dual.kicad_mod',
+                    'PowerPAK_SO-8_Single.kicad_mod',
+                    'Texas_R-PDSO-N5.kicad_mod',
+                    'TSOP-I-32_18.4x8mm_P0.5mm',            # Remvoed, the script can not handle wide as this one
+                    'TSOP-I-48_18.4x12mm_P0.5mm',           # Remvoed, the script can not handle wide as this one
+                    'TSOP-I-56_18.4x14mm_P0.5mm',           # Remvoed, the script can not handle wide as this one
+                ]
+
+#
+# If a foot print file contian a model name (xxxx.wrl) that is in the SpecialModels list 
+# it will will be created with those parameters given in the list
+#
+# model, D1, E1, E, e, b, npx, npy, excluded_pins
+#
+SpecialModels =[
+                ['MSOP-12-16-1EP_3x4mm_P0.5mm_EP1.65x2.85mm',                   3.0,  4.00,  4.40,  0.50,  0.200,   0,  16,   "[2, 4, 13, 15]"],
+                ['MSOP-12-16-1EP_3x4mm_Pitch0.5mm_EP1.65x2.85mm',               3.0,  4.00,  4.40,  0.50,  0.200,   0,  8,   "[2, 4, 13, 15]"],
+                ['MSOP-16-1EP_3x4mm_Pitch0.5mm_EP1.65x2.85mm',                  3.0,  4.00,  4.40,  0.50,  0.200,   0,  8,   "None"],
+                ['MSOP-12-16-1EP_3x4mm_P0.5mm_EP1.65x2.85mm_ThermalVias',       3.0,  4.00,  4.40,  0.50,  0.200,   0,  16,   "[2, 4, 13, 15]"],
+                ['TSSOP-16-1EP_4.4x5mm_Pitch0.65mm_EP3.4x5mm',                  4.4,  5.30,  5.30,  0.65,  0.20,    0,   8,   "None"],
+
+                ['Texas_HTSOP-8-1EP_3.9x4.9mm_P1.27mm_EP2.85x4.9mm_Mask2.4x3.1mm_ThermalVias',  3.90,  4.90,   5.75,  1.27,  0.40,   0,   4,   "None"],
+
+                ['PowerIntegrations_eSOP-12B',          8.89,  10.16,  10.90,  1.78,  0.50,   0,   6,   "[5]"],
+                ['PowerIntegrations_SO-8',              8.89,  10.16,  10.90,  1.27,  0.50,   0,   8,   "None"],
+                ['PowerIntegrations_SO-8B',             8.89,  10.16,  10.90,  1.27,  0.50,   0,   8,   "[6]"],
+                ['PowerIntegrations_SO-8C',             8.89,  10.16,  10.90,  1.27,  0.50,   0,   8,   "[3]"],
+                ['SO-5_4.4x3.6mm_P1.27mm',              4.40,   3.60,   6.30,  1.27,  0.50,   0,   3,   "[2]"],
+                ['SOIC-16W-12_7.5x10.3mm_P1.27mm',      7.50,  10.30,   9.30,  1.27,  0.50,   0,   8,   "[4, 5, 12, 13]"],
+                ['SOIC-16W_5.3x10.2mm_P1.27mm',         5.30,  10.20,   7.10,  1.27,  0.50,   0,   8,   "None"],
+                ['SOIC-16W_7.5x12.8mm_P1.27mm',         5.30,  10.20,   7.10,  1.27,  0.50,   0,   8,   "None"],
+                ['SOIC-28W_7.5x18.7mm_P1.27mm',         7.50,  18.70,   9.40,  1.27,  0.50,   0,  14,   "None"],
+                ['SOIC-8-N7_3.9x4.9mm_P1.27mm',         3.90,   4.90,   5.40,  1.27,  0.50,   0,   4,   "[7]"],
+                ['SOJ-36_10.16x23.49mm_P1.27mm',       10.16,  23.49,  11.66,  1.27,  0.50,   0,  18,   "None"],
+                ['TSSOP-14-1EP_4.4x5mm_P0.65mm',        4.40,   4.50,   5.50,  0.65,  0.25,   0,   7,   "None"],
+                ['TSSOP-28_4.4x9.7mm_Pitch0.65mm',      4.40,   9.70,   5.50,  0.65,  0.25,   0,  14,   "None"],
+                ['TSOP-5_1.65x3.05mm_P0.95mm',          1.65,   3.05,   2.80,  0.95,  0.40,   0,   3,   "[5]"],
+                ['TSOP-6_1.65x3.05mm_P0.95mm',          1.65,   3.05,   2.80,  0.95,  0.40,   0,   3,   "None"],
+                
+                ['HTSOP-8-1EP_3.9x4.9mm_Pitch1.27mm',   3.90,   4.90,   5.40,  1.27,  0.50,   0,   4,   "None"],
+                ['TI_SO-PowerPAD-8',                    3.90,   4.90,   5.40,  1.27,  0.50,   0,   4,   "None"],
+                ['Texas_PWP0020A',                      4.40,   6.50,   5.94,  0.65,  0.20,   0,  10,   "None"],
+                ['ST_MultiPowerSO-30',                 16.00,  17.40,  18.25,  1.00,  0.50,   0,  15,   "None"],
+                ['ST_PowerSSO-24_SlugDown',             7.50,  10.30,   9.87,  0.80,  0.30,   0,  12,   "None"],
+                ['ST_PowerSSO-24_SlugUp',               7.50,  10.30,   9.87,  0.80,  0.30,   0,  12,   "None"],
+                ['ST_PowerSSO-36_SlugUp',               7.50,  10.30,   9.87,  0.50,  0.20,   0,  18,   "None"],
+                ['ST_PowerSSO-36_SlugDown_ThermalVias', 7.50,  10.30,   9.87,  0.50,  0.20,   0,  18,   "None"],
+                ['ST_PowerSSO-36_SlugDown',             7.50,  10.30,   9.87,  0.50,  0.20,   0,  18,   "None"],
+                ['TSOP-I-32_11.8x8mm_P0.5mm',          11.80,   8.00,  13.20,  0.55,  0.20,   0,  14,   "None"],
+                ['TSOP-I-28_11.8x8mm_P0.55mm',         11.80,   8.00,  13.20,  0.55,  0.20,   0,  14,   "None"],
+                ['TSOP-II-44_10.16x18.41mm_P0.8mm',    10.16,  18.41,  11.66,  0.80,  0.25,   0,  22,   "None"],
+                ['TSOP-II-54_22.2x10.16mm_P0.8mm',     10.16,  22.20,  11.66,  0.80,  0.25,   0,  27,   "None"],        # X and Y is revered in the name
+                ['TSSOP-28_4.4x9.7mm_Pitch0.65mm',      4.40,   9.70,   5.90,  0.65,  0.30,   0,  14,   "None"],
+#                ['TSOP-I-32_18.4x8mm_P0.5mm',          18.40,   8.00,  19.90,  0.50,  0.20,   0,  16,   "None"],
+#                ['TSOP-I-48_18.4x12mm_P0.5mm',         18.40,  12.00,  19.90,  0.50,  0.20,   0,  24,   "None"],
+#                ['TSOP-I-56_18.4x14mm_P0.5mm',         18.40,  14.00,  19.90,  0.50,  0.20,   0,  28,   "None"],
+                ]
+                
+
+       
+                
+                
+class A3Dmodel:
+
+    def __init__(self, subf, currfile):
+    
+        self.subf = subf
+        self.currfile = currfile
+
+        self.the = 9.0       # body angle in degrees
+        self.tb_s = 0.15     # top part of body is that much smaller
+        self.c = 0.1         # pin thickness, body center part height
+        self.R1 = 0.1        # pin upper corner, inner radius
+        self.R2 = 0.1        # pin lower corner, inner radius
+        self.S = 0.10        # pin top flat part length (excluding corner arc)
+        self.L = 0.65        # pin bottom flat part length (including corner arc)
+        self.fp_s = True     # True for circular pinmark, False for square pinmark (useful for diodes)
+        self.fp_r = 0.6      # first pin indicator radius
+        self.fp_d = 0.05     # first pin indicator distance from edge
+        self.fp_z = 0.05     # first pin indicator depth
+        self.ef = 0.0        # fillet of edges  Note: bigger bytes model with fillet
+        self.cc1 = 0.25      # 0.45 chamfer of the 1st pin corner
+        self.D1 = 0.0        # body length
+        self.E1 = 0.0        # body width
+        self.E =  0.0        # body overall width
+        self.A1 = 0.1        # body-board separation
+        self.A2 = 0.0        # body height
+        self.b = 0.0         # pin width
+        self.e = 0.0         # pin (center-to-center) distance
+        self.npx = 0         # number of pins along X axis (width)
+        self.npy = 0         # number of pins along y axis (length)
+        self.epad = 'None'   # e Pad
+        self.excluded_pins = 'None' #no pin excluded
+        self.old_modelName = '' #modelName
+        self.modelName = '' #modelName
+        self.rotation = -90   # rotation if required
+        self.numpin = 0
+    #
+    # Print the module on stdout, for debuging purpose
+    #
+    def Print(self):
+        print("self.subf          " + self.subf)
+        print("self.currfile      " + self.currfile)
+        print("self.D1              " + self.D1)
+        print("self.E1              " + self.E1)
+        print("self.E               " + self.E)
+        print("self.A1              " + self.A1)
+        print("self.A2              " + self.A2)
+        print("self.b               " + self.b)
+        print("self.e               " + self.e)
+        print("self.npx             " + self.npx)
+        print("self.npy             " + self.npy)
+        print("self.epad            " + self.epad)
+        print("self.excluded_pins   " + self.excluded_pins)
+        
+    #
+    # Scan and extract information from the foot print file
+    #
+    def ReadFile(self):
+        
+
+        #
+        # Extract what is possible from the model name
+        #
+#        print("self.subf " + self.subf)
+        li0 = self.subf.replace("_Pad", "_XXX")
+        li2 = li0.replace("_PullBack", "_XXX")
+        li3 = li2.replace("_PQFN", "_XXX")
+        li0 = li3.replace("_Pitch", "_P")
+        li1 = li0.replace("Linear_MSOP-", "Linear-MSOP-")
+        #
+        # Extract pitch
+        #
+        FoundPitch = False
+        if '_P' in li1:
+            spline = li1.split('_P')
+            spline2 = spline[1].split('mm')
+            try:
+                self.e = float(spline2[0])
+                FoundPitch = True
+            except ValueError:
+                print("_P in file name is wrong, skipping " + self.subf)
+                return False
+        else:
+            print("_P dont exist in file name, skipping add to exclude or special list " + self.subf)
+            return False
+        
+        #
+        # Extract body size, 
+        # trying to extract 11.0x15.9mm from HSOP-20-1EP_11.0x15.9mm_P1.27mm_SlugDown
+        #
+        FoundSize = False
+        spline = li1.split('_')
+        spline1 = spline[1].split('mm')
+        spline2 = spline1[0].split('x')
+        if len(spline2) == 2:
+            try:
+                self.E1 = float(spline2[0])
+            except ValueError:
+                print("First parameter in body size parameter in file name is wrong, skipping " + self.subf)
+                return False
+            try:
+                self.D1 = float(spline2[1])
+                FoundSize = True
+            except ValueError:
+                print("Second parameter in body size parameter in file name is wrong, skipping " + self.subf)
+                return False
+            
+        else:
+            print("size is 1 or more than 2 parameters, skipping, add to exclude or special list " + self.subf)
+            return False
+        
+#        print("E1, D1 " + str(self.E1), str(self.D1))
+        #
+        # Extract epad size
+        # trying to extract 3.4x6.5mm from HTSSOP-20-1EP_4.4x6.5mm_P0.65mm_EP3.4x6.5mm.kicad_mod
+        #
+        FoundEPad = False
+        self.epad = 'None'
+        if '_EP' in li1:
+            spline = li1.split('_EP')
+            spline2 = spline[1].split('mm')
+            spline3 = spline2[0].split('x')
+            EPadx = 0.0
+            if len(spline3) == 2:
+                try:
+                    EPadx = float(spline3[0])
+                except ValueError:
+                    print("first EPad parameter in file name is wrong, skipping " + self.subf)
+                    return False
+                try:
+                    EPady = float(spline3[1])
+                    if EPady > (self.D1 - 0.5):
+                        EPady = self.D1 - 0.5
+                        if EPady < 0.3:
+                            EPady = 0.2
+                    self.epad = '(' + str(EPady) + ', ' + str(round(EPadx, 2)) + ')'
+                    FoundEPad = True
+                except ValueError:
+                    print("Second EPad parameter in file name is wrong, skipping " + self.subf)
+                    return False
+                
+            else:
+                print("EPad parameter is 1 or more than 2 parameters, skipping, add to exclude or special list " + self.subf)
+                return False
+        
+#        print("epad " + self.epad)
+        #
+        # Extract number of pins
+        # trying to extract 20 from HTSSOP-20-1EP_4.4x6.5mm_P0.65mm_EP3.4x6.5mm.kicad_mod
+        #
+        FoundPinNum = False
+        self.numpin = 0
+        spline = li1.split('_')
+        spline1 = spline[0].split('-')
+        li1 = spline1[len(spline1) - 1]
+        try:
+            if li1 == '1EP':
+                li1 = spline1[len(spline1) - 2]
+                
+            self.numpin = int(li1)
+            FoundPinNum = True
+        except ValueError:
+            print("Pin number is missing in file name, skipping, add to exclude or special list " + self.subf)
+            return False
+
+#        print("self.numpin " + str(self.numpin))
+        PinPos = []
+        #
+        # Collect all pads to calculte npx and npy
+        #
+        minx = 0.0
+        maxx = 0.0
+        
+        with open(self.currfile) as currf:
+            for line in currf:
+                #
+                if 'pad' in line and ('layers F.Cu F.Paste F.Mask' in line or 'layers F.Cu F.Mask F.Paste' in line) and 'at' in line:
+                    spline = line.split('at ')
+                    spline2 = spline[1].split(')')
+                    spline3 = spline2[0].split(' ')
+                    x = float(spline3[0])
+                    y = float(spline3[1])
+                    minx = min(minx, x)
+                    maxx = max(maxx, x)
+                    PinMissing = True
+                    for i in range(len(PinPos)):
+                        if math.fabs(PinPos[i][0] - x) < 0.0001:
+                            PinMissing = False
+                            PinPos[i][2] = PinPos[i][2] + 1
+                    if PinMissing:
+                        PinPos.append([x, y, 1])
+
+                    spline = line.split('size ')
+                    spline2 = spline[1].split(')')
+                    spline3 = spline2[0].split(' ')
+                    w = float(spline3[0])
+                    h = float(spline3[1])
+                    self.b = round(h * 0.70, 2)
+                    if self.b > (self.e / 2.5):
+                        #
+                        # Pad is probably rotated
+                        #
+                        self.b = round(self.e / 2.5, 2)
+
+                    self.E = (maxx - minx) + 1.0
+#        for i in range(len(PinPos)):
+#            print("PinPos[" + str(i) + "] = " + str(PinPos[i][0]) + ", " + str(PinPos[i][1]) + ", " + str(PinPos[i][2]))
+
+        if len(PinPos) == 2:
+            #
+            # Only got pins along y-axis
+            #
+            if PinPos[0][2] == PinPos[1][2]:
+                self.npy = 0
+                self.npx = PinPos[0][2]
+            else:
+                print("Pads are unequal on left and right side, skipping, add to exclude or special list " + self.subf)
+                return False
+        else:
+            ssum = 0
+            hnum = 0
+            for i in range(len(PinPos)):
+                ssum = ssum + PinPos[i][2]
+                if PinPos[i][2] > hnum:
+                    hnum = PinPos[i][2]
+            #
+            if ssum == self.numpin:
+                #
+                # number of pads is equal to the number of found
+                #
+                self.npx = hnum
+                self.npy = int((self.numpin - (hnum + hnum)) / 2)
+            else:
+                print("Pads are missing, skipping, add to exclude or special list " + self.subf)
+                return False
+            
+            
+        if self.npx == 0 and self.npy == 0:
+            print("Could not calculte number of pads, skipping, add to exclude or special list " + self.subf)
+            sys.exit()
+            return False
+        
+        return True
+            
+    #
+    # Add a finnished 3D model to the ResultFile and MakeAllfile
+    #
+    def PrintMissingModels(self, datafile, commandfile):
+
+
+        
+        datafile.write("    '" + self.model + "': Params(\n")
+        datafile.write("        #\n")
+        datafile.write("        # " + self.descr + "\n")
+        datafile.write("        # This model have been auto generated based on the foot print file\n")
+        datafile.write("        # A number of paramters have been fixed or guessed, such as A2\n")
+        datafile.write("        # \n")
+        datafile.write("        # The foot print that uses this 3D model is " + self.subf + "\n")
+        datafile.write("        # \n")
+        datafile.write('        the = ' + str(round(self.the, 2)) + ',         # body angle in degrees\n')
+        datafile.write('        tb_s = ' + str(round(self.tb_s, 2)) + ',       # top part of body is that much smaller\n')
+        datafile.write('        c = ' + str(round(self.c, 2)) + ',           # pin thickness, body center part height\n')
+        datafile.write('        R1 = ' + str(round(self.R1, 2)) + ',          # pin upper corner, inner radius\n')
+        datafile.write('        R2 = ' + str(round(self.R2, 2)) + ',          # pin lower corner, inner radius\n')
+        datafile.write('        S  = ' + str(round(self.S, 2)) + ',          # pin top flat part length (excluding corner arc)\n')
+        datafile.write('#        L = ' + str(round(self.L, 2)) + ',         # pin bottom flat part length (including corner arc)\n')
+        datafile.write('        fp_s = ' + str(round(self.fp_s, 2)) + ',          # True for circular pinmark, False for square pinmark (useful for diodes)\n')
+
+        if self.D1 < 4.0 or self.E1 < 4.0:
+            if self.D1 < 2.0 or self.E1 < 2.0:
+                datafile.write("        fp_r = 0.1,        # first pin indicator radius\n")
+                datafile.write("        fp_d = 0.05,       # first pin indicator distance from edge\n")
+            else:
+                datafile.write("        fp_r = 0.2,        # first pin indicator radius\n")
+                datafile.write("        fp_d = 0.3,        # first pin indicator distance from edge\n")
+        else:
+            datafile.write("        fp_r = 0.4,        # first pin indicator radius\n")
+            datafile.write("        fp_d = 0.5,        # first pin indicator distance from edge\n")
+
+        datafile.write('        fp_z = ' + str(round(self.fp_z , 2)) + ',       # first pin indicator depth\n')
+        datafile.write('        ef = ' + str(round(self.ef, 2)) + ',          # fillet of edges  Note: bigger bytes model with fillet\n')
+        datafile.write('        cc1 = ' + str(round(self.cc1, 2)) + ',        # 0.45 chamfer of the 1st pin corner\n')
+        datafile.write('        D1 = ' + str(round(self.D1, 2)) + ',         # body length\n')
+        datafile.write('        E1 = ' + str(round(self.E1, 2)) + ',         # body width\n')
+        datafile.write('        E = ' + str(round(self.E, 2)) + ',          # body overall width\n')
+        datafile.write('        A1 = ' + str(round(self.A1 , 2)) + ',          # body-board separation\n')
+
+        if self.D1 < 4.0 or self.E1 < 4.0:
+            datafile.write("        A2 = 1.0,          # body height\n")
+        else:
+            datafile.write("        A2 = 1.5,          # body height\n")
+
+        datafile.write('        b = ' + str(round(self.b, 2)) + ',          # pin width\n')
+        datafile.write('        e = ' + str(round(self.e, 2)) + ',          # pin (center-to-center) distance\n')
+        datafile.write('        npx = ' + str(round(self.npx, 2)) + ',           # number of pins along X axis (width)\n')
+        datafile.write('        npy = ' + str(round(self.npy, 2)) + ',           # number of pins along y axis (length)\n')
+        datafile.write('        epad = ' + self.epad + ',       # e Pad\n')
+        datafile.write('        excluded_pins = ' + str(self.excluded_pins) + ',          # pin excluded\n')
+        datafile.write("        old_modelName = '" + self.old_modelName + "',            # modelName\n")
+        datafile.write("        modelName = '" + self.modelName + "',            # modelName\n")
+        datafile.write('        rotation = ' + str(self.rotation) + ',      # rotation if required\n')
+        
+        datafile.write('        ),\n\n')
+
+        #
+        # Create the FreeCad command line
+        #
+        commandfile.write(FreeCadExe + ' ' + MainGenerator + '  model_filter=' + self.model + '\n')
+
+#
+# Check if a foot print file should be excluded form being scanned
+#
+def DoNotExcludeModel(subf):
+    #
+    # Shall the model be excluded based on it's name
+    #
+    for n in ExcludeModels:
+        if n == subf:
+            #
+            # Exclude this 3D model from creation
+            #
+            print("Is in exclude list " + subf);
+            return False
+    
+    return True
+
+        
+#
+# Check if a 3D model given in the foot print file is misisng in the 3D model directory
+#
+def ModelDoNotExist(subf, currfile, NewA3Dmodel):
+    #
+    # Shall the model be excluded becaouse it already exist
+    #
+    with open(currfile) as currf:
+        for line in currf:
+            #
+            if 'descr' in line:
+                spline = line. split('"')
+                if len(spline) > 1:
+                    if len(spline[1]) > 2:
+                        NewA3Dmodel.descr = spline[1]
+            #
+            if 'model' in line:
+                line2 = line.replace("\\", "/")
+                line3 = line2.replace("\r", "/")
+                line4 = line3.replace("\n", "/")
+                line2 = line4.replace("\t", "/")
+                spline = line2.split('/')
+                if len(spline) > 2:
+                    line2 = spline[1] + '/' + spline[2]
+                    Model3DFile = '../kicad-packages3D/' + line2
+                    Model3DFilePath = Path(Model3DFile)
+                    if Model3DFilePath.exists():
+                        #
+                        # 3D model already exist
+                        #
+#                        print("3D model exist, skipping it    " + subf);
+                        return False
+                    filename = spline[2]
+                    spline2 = spline[2].split('.wrl')
+                    NewA3Dmodel.model = spline2[0]
+                    NewA3Dmodel.old_modelName = spline2[0]
+                    NewA3Dmodel.modelName = spline2[0]
+                else:
+                    print("Exclude  " + subf + "   Something fuzzy about 3D model name")
+                    return False
+    
+    return True
+
+        
+#
+# Check if a 3D model should be created from the SpecialModel list
+#
+def IsNotSpecialModel(NewA3Dmodel):
+    #
+    # Is it a special model that do not require parsing
+    #
+    for n in SpecialModels:
+        if n[0] == NewA3Dmodel.model:
+            #
+            # This mdel is special setup
+            # model, D1, E1, E, e, b, npx, npy, excluded_pins
+            
+            NewA3Dmodel.E1 = n[1]
+            NewA3Dmodel.D1 = n[2]
+            NewA3Dmodel.E = n[3]
+            NewA3Dmodel.e = n[4]
+            NewA3Dmodel.b = n[5]
+            NewA3Dmodel.npy = n[6]
+            NewA3Dmodel.npx = n[7]
+            NewA3Dmodel.excluded_pins = n[8]
+#            print("Special  " + NewA3Dmodel.subf)
+            return False
+
+    return True
+    
+
+#
+# Find all missing models
+#
+def FindMissingModels():
+
+    #
+    print("Checking dir: " + FPDir)
+    currdir = FPDir
+    #
+    for subpath, subdirs, subfiles in os.walk(currdir):
+        for subf in subfiles:
+            if subf.endswith('.kicad_mod'):
+                currfile = os.path.join(subpath, subf)
+                #
+                NewA3Dmodel = A3Dmodel(subf, currfile)
+                #
+                # Shall the model be excluded based on it's name
+                #
+                AddMissing = DoNotExcludeModel(subf)
+
+                if AddMissing:
+                    #
+                    # Shall the model be excluded because it already exist
+                    #
+                    AddMissing = ModelDoNotExist(subf, currfile, NewA3Dmodel)
+                    
+                if AddMissing:
+                    #
+                    # Is it a special model
+                    #
+                    if IsNotSpecialModel(NewA3Dmodel):
+                        #
+                        # Parse the data file
+                        #
+                        AddMissing = NewA3Dmodel.ReadFile()
+                        
+                        
+                if AddMissing:
+                    for n in MissingModels:
+                        if n.model == NewA3Dmodel.model:
+                            AddMissing = False
+                    #
+                    if AddMissing:
+                        print("Creating " + NewA3Dmodel.model);
+                        MissingModels.append(NewA3Dmodel)
+#                    NewA3Dmodel.Print()
+
+
+def SaveMissingModels():
+
+    datafile = open(ResultFile, "w") 
+    commandfile = open(MakeAllfile, "w") 
+    
+    commandfile.write('#!/bin/sh\n\n')
+    
+    for n in MissingModels:
+        n.PrintMissingModels(datafile, commandfile)
+
+    datafile.close()
+    commandfile.close()
+        
+
+def main(argv):
+
+    MissingModels = []
+    FindMissingModels()
+    SaveMissingModels()
+        
+if __name__ == "__main__":
+    main(sys.argv[1:])
+        
+        

--- a/cadquery/FCAD_script_generator/GW_QFP_SOIC_SSOP_TSSOP_SOT/cq_parameters_soic.py
+++ b/cadquery/FCAD_script_generator/GW_QFP_SOIC_SSOP_TSSOP_SOT/cq_parameters_soic.py
@@ -430,4 +430,2483 @@ part_params = {
         modelName = 'ST_MultiPowerSO-30', #modelName
         rotation = -90,   # rotation if required
         ),
+    'HSOP-36-1EP_11.0x15.9mm_P0.65mm_SlugUp': Params(
+        #
+        # HSOP 11.0x15.9mm Pitch 0.65mm Slug Up (PowerSO-36) [JEDEC MO-166] (http://www.st.com/resource/en/datasheet/vn808cm-32-e.pdf, http://www.st.com/resource/en/application_note/cd00003801.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is HSOP-36-1EP_11.0x15.9mm_P0.65mm_SlugUp.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 15.9,         # body length
+        E1 = 11.0,         # body width
+        E = 14.7,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.26,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 18,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'HSOP-36-1EP_11.0x15.9mm_P0.65mm_SlugUp',            # modelName
+        modelName = 'HSOP-36-1EP_11.0x15.9mm_P0.65mm_SlugUp',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'HSOP-8-1EP_3.9x4.9mm_P1.27mm_EP2.41x3.1mm': Params(
+        #
+        # HSOP, 8 Pin (https://www.st.com/resource/en/datasheet/l5973d.pdf), generated with kicad-footprint-generator ipc_gullwing_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is HSOP-8-1EP_3.9x4.9mm_P1.27mm_EP2.41x3.1mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 4.9,         # body length
+        E1 = 3.9,         # body width
+        E = 6.3,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.42,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 4,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = (3.1, 2.41),       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'HSOP-8-1EP_3.9x4.9mm_P1.27mm_EP2.41x3.1mm',            # modelName
+        modelName = 'HSOP-8-1EP_3.9x4.9mm_P1.27mm_EP2.41x3.1mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'HTSOP-8-1EP_3.9x4.9mm_P1.27mm_EP2.4x3.2mm': Params(
+        #
+        # HTSOP, 8 Pin (https://media.digikey.com/pdf/Data%20Sheets/Rohm%20PDFs/BD9G341EFJ.pdf), generated with kicad-footprint-generator ipc_gullwing_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is HTSOP-8-1EP_3.9x4.9mm_P1.27mm_EP2.4x3.2mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 4.9,         # body length
+        E1 = 3.9,         # body width
+        E = 6.3,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.42,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 4,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = (3.2, 2.4),       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'HTSOP-8-1EP_3.9x4.9mm_P1.27mm_EP2.4x3.2mm',            # modelName
+        modelName = 'HTSOP-8-1EP_3.9x4.9mm_P1.27mm_EP2.4x3.2mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TSSOP-16-1EP_4.4x5mm_Pitch0.65mm_EP3.4x5mm': Params(
+        #
+        # 16-Lead Plastic HTSSOP (4.4x5x1.2mm); Thermal pad; (http://www.ti.com/lit/ds/symlink/drv8833.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is HTSSOP-16-1EP_4.4x5mm_P0.65mm_EP3.4x5mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 5.3,         # body length
+        E1 = 4.4,         # body width
+        E = 5.3,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.2,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 8,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TSSOP-16-1EP_4.4x5mm_Pitch0.65mm_EP3.4x5mm',            # modelName
+        modelName = 'TSSOP-16-1EP_4.4x5mm_Pitch0.65mm_EP3.4x5mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'HTSSOP-20-1EP_4.4x6.5mm_P0.65mm_EP3.4x6.5mm_Mask2.75x3.43mm': Params(
+        #
+        # HTSSOP, 20 Pin (http://www.ti.com/lit/ds/symlink/tlc5971.pdf#page=37&zoom=160,-90,3), generated with kicad-footprint-generator ipc_gullwing_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is HTSSOP-20-1EP_4.4x6.5mm_P0.65mm_EP3.4x6.5mm_Mask2.75x3.43mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 6.5,         # body length
+        E1 = 4.4,         # body width
+        E = 6.72,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.26,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 10,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = (6.0, 3.4),       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'HTSSOP-20-1EP_4.4x6.5mm_P0.65mm_EP3.4x6.5mm_Mask2.75x3.43mm',            # modelName
+        modelName = 'HTSSOP-20-1EP_4.4x6.5mm_P0.65mm_EP3.4x6.5mm_Mask2.75x3.43mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP3.4x7.8mm_Mask2.4x4.68mm': Params(
+        #
+        # HTSSOP, 24 Pin (http://www.ti.com/lit/ds/symlink/tps703.pdf), generated with kicad-footprint-generator ipc_gullwing_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP3.4x7.8mm_Mask2.4x4.68mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 7.8,         # body length
+        E1 = 4.4,         # body width
+        E = 6.72,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.26,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 12,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = (7.3, 3.4),       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP3.4x7.8mm_Mask2.4x4.68mm',            # modelName
+        modelName = 'HTSSOP-24-1EP_4.4x7.8mm_P0.65mm_EP3.4x7.8mm_Mask2.4x4.68mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'HTSSOP-32-1EP_6.1x11mm_P0.65mm_EP5.2x11mm': Params(
+        #
+        # HTSSOP32: plastic thin shrink small outline package; 32 leads; body width 6.1 mm; lead pitch 0.65 mm (see NXP SSOP-TSSOP-VSO-REFLOW.pdf and sot487-1_po.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is HTSSOP-32-1EP_6.1x11mm_P0.65mm_EP5.2x11mm_Mask4.11x4.36mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 11.0,         # body length
+        E1 = 6.1,         # body width
+        E = 8.3,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.26,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 16,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = (10.5, 5.2),       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'HTSSOP-32-1EP_6.1x11mm_P0.65mm_EP5.2x11mm',            # modelName
+        modelName = 'HTSSOP-32-1EP_6.1x11mm_P0.65mm_EP5.2x11mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'HTSSOP-38-1EP_6.1x12.5mm_P0.65mm_EP5.2x12.5mm_Mask3.39x6.35mm': Params(
+        #
+        # HTSSOP, 38 Pin (http://www.ti.com/lit/ds/symlink/tlc5951.pdf#page=47&zoom=140,-67,15), generated with kicad-footprint-generator ipc_gullwing_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is HTSSOP-38-1EP_6.1x12.5mm_P0.65mm_EP5.2x12.5mm_Mask3.39x6.35mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 12.5,         # body length
+        E1 = 6.1,         # body width
+        E = 8.43,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.26,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 19,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = (12.0, 5.2),       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'HTSSOP-38-1EP_6.1x12.5mm_P0.65mm_EP5.2x12.5mm_Mask3.39x6.35mm',            # modelName
+        modelName = 'HTSSOP-38-1EP_6.1x12.5mm_P0.65mm_EP5.2x12.5mm_Mask3.39x6.35mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'Linear_MSOP-12-16-1EP_3x4mm_P0.5mm': Params(
+        #
+        # 12-Lead Plastic Micro Small Outline Package (MS) [MSOP], variant of MSOP-16 (see http://cds.linear.com/docs/en/datasheet/3630fd.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is Linear_MSOP-12-16-1EP_3x4mm_P0.5mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 4.0,         # body length
+        E1 = 3.0,         # body width
+        E = 5.21,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.2,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 6,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'Linear_MSOP-12-16-1EP_3x4mm_P0.5mm',            # modelName
+        modelName = 'Linear_MSOP-12-16-1EP_3x4mm_P0.5mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'MSOP-12-16-1EP_3x4mm_Pitch0.5mm_EP1.65x2.85mm': Params(
+        #
+        # 10-Lead Plastic Micro Small Outline Package (MS) [MSOP] (see Microchip Packaging Specification 00000049BS.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is MSOP-12-16-1EP_3x4mm_P0.5mm_EP1.65x2.85mm_ThermalVias.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 4.0,         # body length
+        E1 = 3.0,         # body width
+        E = 4.4,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.2,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 8,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = [2, 4, 13, 15],          # pin excluded
+        old_modelName = 'MSOP-12-16-1EP_3x4mm_Pitch0.5mm_EP1.65x2.85mm',            # modelName
+        modelName = 'MSOP-12-16-1EP_3x4mm_Pitch0.5mm_EP1.65x2.85mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'MSOP-16-1EP_3x4mm_Pitch0.5mm_EP1.65x2.85mm': Params(
+        #
+        # 10-Lead Plastic Micro Small Outline Package (MS) [MSOP] (see Microchip Packaging Specification 00000049BS.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is MSOP-16-1EP_3x4mm_P0.5mm_EP1.65x2.85mm_ThermalVias.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 4.0,         # body length
+        E1 = 3.0,         # body width
+        E = 4.4,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.2,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 8,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'MSOP-16-1EP_3x4mm_Pitch0.5mm_EP1.65x2.85mm',            # modelName
+        modelName = 'MSOP-16-1EP_3x4mm_Pitch0.5mm_EP1.65x2.85mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'MSOP-8-1EP_3x3mm_P0.65mm_EP2.54x2.8mm': Params(
+        #
+        # MME Package; 8-Lead Plastic MSOP, Exposed Die Pad (see Microchip http://ww1.microchip.com/downloads/en/DeviceDoc/mic5355_6.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is MSOP-8-1EP_3x3mm_P0.65mm_EP2.54x2.8mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 3.0,         # body length
+        E1 = 3.0,         # body width
+        E = 5.8,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.26,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 4,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = (2.5, 2.54),       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'MSOP-8-1EP_3x3mm_P0.65mm_EP2.54x2.8mm',            # modelName
+        modelName = 'MSOP-8-1EP_3x3mm_P0.65mm_EP2.54x2.8mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'PowerIntegrations_eSOP-12B': Params(
+        #
+        # eSOP-12B SMT Flat Package with Heatsink Tab, see https://ac-dc.power.com/sites/default/files/product-docs/topswitch-jx_family_datasheet.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is PowerIntegrations_eSOP-12B.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 10.16,         # body length
+        E1 = 8.89,         # body width
+        E = 10.9,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.5,          # pin width
+        e = 1.78,          # pin (center-to-center) distance
+        npx = 6,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = [5],          # pin excluded
+        old_modelName = 'PowerIntegrations_eSOP-12B',            # modelName
+        modelName = 'PowerIntegrations_eSOP-12B',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'PowerIntegrations_SO-8': Params(
+        #
+        # Power-Integrations variant of 8-Lead Plastic Small Outline (SN) - Narrow, 3.90 mm Body [SOIC], see https://ac-dc.power.com/sites/default/files/product-docs/senzero_family_datasheet.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is PowerIntegrations_SO-8.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 10.16,         # body length
+        E1 = 8.89,         # body width
+        E = 10.9,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.5,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 8,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'PowerIntegrations_SO-8',            # modelName
+        modelName = 'PowerIntegrations_SO-8',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'PowerIntegrations_SO-8B': Params(
+        #
+        # Power-Integrations variant of 8-Lead Plastic Small Outline (SN) - Narrow, 3.90 mm Body [SOIC], see https://www.mouser.com/ds/2/328/linkswitch-pl_family_datasheet-12517.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is PowerIntegrations_SO-8B.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 10.16,         # body length
+        E1 = 8.89,         # body width
+        E = 10.9,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.5,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 8,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = [6],          # pin excluded
+        old_modelName = 'PowerIntegrations_SO-8B',            # modelName
+        modelName = 'PowerIntegrations_SO-8B',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'PowerIntegrations_SO-8C': Params(
+        #
+        # Power-Integrations variant of 8-Lead Plastic Small Outline (SN) - Narrow, 3.90 mm Body [SOIC], see https://www.mouser.com/ds/2/328/linkswitch-pl_family_datasheet-12517.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is PowerIntegrations_SO-8C.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 10.16,         # body length
+        E1 = 8.89,         # body width
+        E = 10.9,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.5,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 8,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = [3],          # pin excluded
+        old_modelName = 'PowerIntegrations_SO-8C',            # modelName
+        modelName = 'PowerIntegrations_SO-8C',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'QSOP-20_3.9x8.7mm_P0.635mm': Params(
+        #
+        # 20-Lead Plastic Shrink Small Outline Narrow Body (http://www.analog.com/media/en/technical-documentation/data-sheets/ADuM7640_7641_7642_7643.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is QSOP-20_3.9x8.7mm_P0.635mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 8.7,         # body length
+        E1 = 3.9,         # body width
+        E = 6.31,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.25,          # pin width
+        e = 0.64,          # pin (center-to-center) distance
+        npx = 10,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'QSOP-20_3.9x8.7mm_P0.635mm',            # modelName
+        modelName = 'QSOP-20_3.9x8.7mm_P0.635mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SO-4_4.4x2.3mm_P1.27mm': Params(
+        #
+        # 4-Lead Plastic Small Outline (SO), see http://datasheet.octopart.com/OPIA403BTRE-Optek-datasheet-5328560.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SO-4_4.4x2.3mm_P1.27mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 2.3,         # body length
+        E1 = 4.4,         # body width
+        E = 7.3,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.45,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 2,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SO-4_4.4x2.3mm_P1.27mm',            # modelName
+        modelName = 'SO-4_4.4x2.3mm_P1.27mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SO-4_4.4x3.6mm_P2.54mm': Params(
+        #
+        # 4-Lead Plastic Small Outline (SO), see https://www.elpro.org/de/index.php?controller=attachment&id_attachment=339
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SO-4_4.4x3.6mm_P2.54mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 3.6,         # body length
+        E1 = 4.4,         # body width
+        E = 7.3,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.45,          # pin width
+        e = 2.54,          # pin (center-to-center) distance
+        npx = 2,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SO-4_4.4x3.6mm_P2.54mm',            # modelName
+        modelName = 'SO-4_4.4x3.6mm_P2.54mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SO-4_4.4x4.3mm_P2.54mm': Params(
+        #
+        # 4-Lead Plastic Small Outline (SO), see https://docs.broadcom.com/docs/AV02-0173EN
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SO-4_4.4x4.3mm_P2.54mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 4.3,         # body length
+        E1 = 4.4,         # body width
+        E = 7.0,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.84,          # pin width
+        e = 2.54,          # pin (center-to-center) distance
+        npx = 2,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SO-4_4.4x4.3mm_P2.54mm',            # modelName
+        modelName = 'SO-4_4.4x4.3mm_P2.54mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SO-4_7.6x3.6mm_P2.54mm': Params(
+        #
+        # 4-Lead Plastic Small Outline (SO) (http://www.everlight.com/file/ProductFile/201407061745083848.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SO-4_7.6x3.6mm_P2.54mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 3.6,         # body length
+        E1 = 7.6,         # body width
+        E = 10.5,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.45,          # pin width
+        e = 2.54,          # pin (center-to-center) distance
+        npx = 2,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SO-4_7.6x3.6mm_P2.54mm',            # modelName
+        modelName = 'SO-4_7.6x3.6mm_P2.54mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SO-5_4.4x3.6mm_P1.27mm': Params(
+        #
+        # 5-Lead Plastic Small Outline (SO), see https://docs.broadcom.com/cs/Satellite?blobcol=urldata&blobheader=application%2Fpdf&blobheadername1=Content-Disposition&blobheadername2=Content-Type&blobheadername3=MDT-Type&blobheadervalue1=attachment%3Bfilename%3DIPD-Selection-Guide_AV00-0254EN_030617.pdf&blobheadervalue2=application%2Fx-download&blobheadervalue3=abinary%253B%2Bcharset%253DUTF-8&blobkey=id&blobnocache=true&blobtable=MungoBlobs&blobwhere=1430884105675&ssbinary=true
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SO-5_4.4x3.6mm_P1.27mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 3.6,         # body length
+        E1 = 4.4,         # body width
+        E = 6.3,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.5,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 3,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = [2],          # pin excluded
+        old_modelName = 'SO-5_4.4x3.6mm_P1.27mm',            # modelName
+        modelName = 'SO-5_4.4x3.6mm_P1.27mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SO-6_4.4x3.6mm_P1.27mm': Params(
+        #
+        # 6-Lead Plastic Small Outline (SO), see https://docs.broadcom.com/cs/Satellite?blobcol=urldata&blobheader=application%2Fpdf&blobheadername1=Content-Disposition&blobheadername2=Content-Type&blobheadername3=MDT-Type&blobheadervalue1=attachment%3Bfilename%3DIPD-Selection-Guide_AV00-0254EN_030617.pdf&blobheadervalue2=application%2Fx-download&blobheadervalue3=abinary%253B%2Bcharset%253DUTF-8&blobkey=id&blobnocache=true&blobtable=MungoBlobs&blobwhere=1430884105675&ssbinary=true
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SO-6_4.4x3.6mm_P1.27mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 3.6,         # body length
+        E1 = 4.4,         # body width
+        E = 7.3,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.45,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 3,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SO-6_4.4x3.6mm_P1.27mm',            # modelName
+        modelName = 'SO-6_4.4x3.6mm_P1.27mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SO-8_5.3x6.2mm_P1.27mm': Params(
+        #
+        # 8-Lead Plastic Small Outline, 5.3x6.2mm Body (http://www.ti.com.cn/cn/lit/ds/symlink/tl7705a.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SO-8_5.3x6.2mm_P1.27mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 6.2,         # body length
+        E1 = 5.3,         # body width
+        E = 8.4,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.39,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 4,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SO-8_5.3x6.2mm_P1.27mm',            # modelName
+        modelName = 'SO-8_5.3x6.2mm_P1.27mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SOIC-16W-12_7.5x10.3mm_P1.27mm': Params(
+        #
+        # SOIC-16 With 12 Pin Placed - Wide, 7.50 mm Body [SOIC] (https://docs.broadcom.com/docs/AV02-0169EN)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SOIC-16W-12_7.5x10.3mm_P1.27mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 10.3,         # body length
+        E1 = 7.5,         # body width
+        E = 9.3,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.5,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 8,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = [4, 5, 12, 13],          # pin excluded
+        old_modelName = 'SOIC-16W-12_7.5x10.3mm_P1.27mm',            # modelName
+        modelName = 'SOIC-16W-12_7.5x10.3mm_P1.27mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SOIC-16W_5.3x10.2mm_P1.27mm': Params(
+        #
+        # 16-Lead Plastic Small Outline (SO) - Wide, 5.3 mm Body (http://www.ti.com/lit/ml/msop002a/msop002a.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SOIC-16W_5.3x10.2mm_P1.27mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 10.2,         # body length
+        E1 = 5.3,         # body width
+        E = 7.1,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.5,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 8,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SOIC-16W_5.3x10.2mm_P1.27mm',            # modelName
+        modelName = 'SOIC-16W_5.3x10.2mm_P1.27mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SOIC-16W_7.5x12.8mm_P1.27mm': Params(
+        #
+        # 16-Lead Plastic Small Outline (SO) - Wide, 7.50 mm x 12.8 mm Body (http://www.analog.com/media/en/technical-documentation/data-sheets/ADuM6000.PDF)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SOIC-16W_7.5x12.8mm_P1.27mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 10.2,         # body length
+        E1 = 5.3,         # body width
+        E = 7.1,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.5,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 8,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SOIC-16W_7.5x12.8mm_P1.27mm',            # modelName
+        modelName = 'SOIC-16W_7.5x12.8mm_P1.27mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SOIC-28W_7.5x18.7mm_P1.27mm': Params(
+        #
+        # 28-Lead Plastic Small Outline (SO) - Wide, 7.50 mm X 18.7 mm Body [SOIC] (https://www.akm.com/akm/en/file/datasheet/AK5394AVS.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SOIC-28W_7.5x18.7mm_P1.27mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 18.7,         # body length
+        E1 = 7.5,         # body width
+        E = 9.4,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.5,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 14,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SOIC-28W_7.5x18.7mm_P1.27mm',            # modelName
+        modelName = 'SOIC-28W_7.5x18.7mm_P1.27mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SOIC-8-N7_3.9x4.9mm_P1.27mm': Params(
+        #
+        # 8-Lead Plastic Small Outline (SN) - Narrow, 3.90 mm Body [SOIC], pin 7 removed (Microchip Packaging Specification 00000049BS.pdf, http://www.onsemi.com/pub/Collateral/NCP1207B.PDF)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SOIC-8-N7_3.9x4.9mm_P1.27mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 4.9,         # body length
+        E1 = 3.9,         # body width
+        E = 5.4,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.5,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 4,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = [7],          # pin excluded
+        old_modelName = 'SOIC-8-N7_3.9x4.9mm_P1.27mm',            # modelName
+        modelName = 'SOIC-8-N7_3.9x4.9mm_P1.27mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SOJ-36_10.16x23.49mm_P1.27mm': Params(
+        #
+        # SOJ, 36 Pin (http://www.issi.com/WW/pdf/61-64C5128AL.pdf), generated with kicad-footprint-generator ipc_gullwing_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SOJ-36_10.16x23.49mm_P1.27mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 23.49,         # body length
+        E1 = 10.16,         # body width
+        E = 11.66,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.5,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 18,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SOJ-36_10.16x23.49mm_P1.27mm',            # modelName
+        modelName = 'SOJ-36_10.16x23.49mm_P1.27mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SOP-16_7.5x10.4mm_P1.27mm': Params(
+        #
+        # 16-Lead Plastic Small Outline http://www.vishay.com/docs/49633/sg2098.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SOP-16_7.5x10.4mm_P1.27mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 10.4,         # body length
+        E1 = 7.5,         # body width
+        E = 10.4,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.51,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 8,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SOP-16_7.5x10.4mm_P1.27mm',            # modelName
+        modelName = 'SOP-16_7.5x10.4mm_P1.27mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SOP-18_7.0x12.5mm_P1.27mm': Params(
+        #
+        #  SOP, 18 Pin (https://toshiba.semicon-storage.com/info/docget.jsp?did=30523), generated with kicad-footprint-generator package_soic_sop.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SOP-18_7.0x12.5mm_P1.27mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 12.5,         # body length
+        E1 = 7.0,         # body width
+        E = 9.72,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.42,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 9,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SOP-18_7.0x12.5mm_P1.27mm',            # modelName
+        modelName = 'SOP-18_7.0x12.5mm_P1.27mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SSO-6_6.8x4.6mm_P1.27mm_Clearance7mm': Params(
+        #
+        # 8-Lead Plastic Stretched Small Outline (SSO/Stretched SO), see https://docs.broadcom.com/cs/Satellite?blobcol=urldata&blobheader=application%2Fpdf&blobheadername1=Content-Disposition&blobheadername2=Content-Type&blobheadername3=MDT-Type&blobheadervalue1=attachment%3Bfilename%3DIPD-Selection-Guide_AV00-0254EN_030617.pdf&blobheadervalue2=application%2Fx-download&blobheadervalue3=abinary%253B%2Bcharset%253DUTF-8&blobkey=id&blobnocache=true&blobtable=MungoBlobs&blobwhere=1430884105675&ssbinary=true
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SSO-6_6.8x4.6mm_P1.27mm_Clearance7mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 4.6,         # body length
+        E1 = 6.8,         # body width
+        E = 9.54,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.45,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 3,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SSO-6_6.8x4.6mm_P1.27mm_Clearance7mm',            # modelName
+        modelName = 'SSO-6_6.8x4.6mm_P1.27mm_Clearance7mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SSO-6_6.8x4.6mm_P1.27mm_Clearance8mm': Params(
+        #
+        # 8-Lead Plastic Stretched Small Outline (SSO/Stretched SO), see https://docs.broadcom.com/cs/Satellite?blobcol=urldata&blobheader=application%2Fpdf&blobheadername1=Content-Disposition&blobheadername2=Content-Type&blobheadername3=MDT-Type&blobheadervalue1=attachment%3Bfilename%3DIPD-Selection-Guide_AV00-0254EN_030617.pdf&blobheadervalue2=application%2Fx-download&blobheadervalue3=abinary%253B%2Bcharset%253DUTF-8&blobkey=id&blobnocache=true&blobtable=MungoBlobs&blobwhere=1430884105675&ssbinary=true
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SSO-6_6.8x4.6mm_P1.27mm_Clearance8mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 4.6,         # body length
+        E1 = 6.8,         # body width
+        E = 11.74,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.45,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 3,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SSO-6_6.8x4.6mm_P1.27mm_Clearance8mm',            # modelName
+        modelName = 'SSO-6_6.8x4.6mm_P1.27mm_Clearance8mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SSO-8_13.6x6.3mm_P1.27mm_Clearance14.2mm': Params(
+        #
+        # 8-Lead Plastic Stretched Small Outline (SSO/Stretched SO), see https://docs.broadcom.com/cs/Satellite?blobcol=urldata&blobheader=application%2Fpdf&blobheadername1=Content-Disposition&blobheadername2=Content-Type&blobheadername3=MDT-Type&blobheadervalue1=attachment%3Bfilename%3DIPD-Selection-Guide_AV00-0254EN_030617.pdf&blobheadervalue2=application%2Fx-download&blobheadervalue3=abinary%253B%2Bcharset%253DUTF-8&blobkey=id&blobnocache=true&blobtable=MungoBlobs&blobwhere=1430884105675&ssbinary=true
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SSO-8_13.6x6.3mm_P1.27mm_Clearance14.2mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 6.3,         # body length
+        E1 = 13.6,         # body width
+        E = 16.96,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.45,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 4,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SSO-8_13.6x6.3mm_P1.27mm_Clearance14.2mm',            # modelName
+        modelName = 'SSO-8_13.6x6.3mm_P1.27mm_Clearance14.2mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SSO-8_6.8x5.9mm_P1.27mm_Clearance7mm': Params(
+        #
+        # 8-Lead Plastic Stretched Small Outline (SSO/Stretched SO), see https://docs.broadcom.com/cs/Satellite?blobcol=urldata&blobheader=application%2Fpdf&blobheadername1=Content-Disposition&blobheadername2=Content-Type&blobheadername3=MDT-Type&blobheadervalue1=attachment%3Bfilename%3DIPD-Selection-Guide_AV00-0254EN_030617.pdf&blobheadervalue2=application%2Fx-download&blobheadervalue3=abinary%253B%2Bcharset%253DUTF-8&blobkey=id&blobnocache=true&blobtable=MungoBlobs&blobwhere=1430884105675&ssbinary=true
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SSO-8_6.8x5.9mm_P1.27mm_Clearance7mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 5.9,         # body length
+        E1 = 6.8,         # body width
+        E = 9.54,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.45,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 4,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SSO-8_6.8x5.9mm_P1.27mm_Clearance7mm',            # modelName
+        modelName = 'SSO-8_6.8x5.9mm_P1.27mm_Clearance7mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SSO-8_6.8x5.9mm_P1.27mm_Clearance8mm': Params(
+        #
+        # 8-Lead Plastic Stretched Small Outline (SSO/Stretched SO), see https://docs.broadcom.com/cs/Satellite?blobcol=urldata&blobheader=application%2Fpdf&blobheadername1=Content-Disposition&blobheadername2=Content-Type&blobheadername3=MDT-Type&blobheadervalue1=attachment%3Bfilename%3DIPD-Selection-Guide_AV00-0254EN_030617.pdf&blobheadervalue2=application%2Fx-download&blobheadervalue3=abinary%253B%2Bcharset%253DUTF-8&blobkey=id&blobnocache=true&blobtable=MungoBlobs&blobwhere=1430884105675&ssbinary=true
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SSO-8_6.8x5.9mm_P1.27mm_Clearance8mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 5.9,         # body length
+        E1 = 6.8,         # body width
+        E = 11.7,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.45,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 4,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SSO-8_6.8x5.9mm_P1.27mm_Clearance8mm',            # modelName
+        modelName = 'SSO-8_6.8x5.9mm_P1.27mm_Clearance8mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SSO-8_9.6x6.3mm_P1.27mm_Clearance10.5mm': Params(
+        #
+        # 8-Lead Plastic Stretched Small Outline (SSO/Stretched SO), see https://docs.broadcom.com/cs/Satellite?blobcol=urldata&blobheader=application%2Fpdf&blobheadername1=Content-Disposition&blobheadername2=Content-Type&blobheadername3=MDT-Type&blobheadervalue1=attachment%3Bfilename%3DIPD-Selection-Guide_AV00-0254EN_030617.pdf&blobheadervalue2=application%2Fx-download&blobheadervalue3=abinary%253B%2Bcharset%253DUTF-8&blobkey=id&blobnocache=true&blobtable=MungoBlobs&blobwhere=1430884105675&ssbinary=true
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SSO-8_9.6x6.3mm_P1.27mm_Clearance10.5mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 6.3,         # body length
+        E1 = 9.6,         # body width
+        E = 13.5,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.45,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 4,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SSO-8_9.6x6.3mm_P1.27mm_Clearance10.5mm',            # modelName
+        modelName = 'SSO-8_9.6x6.3mm_P1.27mm_Clearance10.5mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SSOP-10_3.9x4.9mm_P1.00mm': Params(
+        #
+        # 10-Lead SSOP, 3.9 x 4.9mm body, 1.00mm pitch (http://www.st.com/resource/en/datasheet/viper01.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SSOP-10_3.9x4.9mm_P1.00mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 4.9,         # body length
+        E1 = 3.9,         # body width
+        E = 6.1,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.36,          # pin width
+        e = 1.0,          # pin (center-to-center) distance
+        npx = 5,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SSOP-10_3.9x4.9mm_P1.00mm',            # modelName
+        modelName = 'SSOP-10_3.9x4.9mm_P1.00mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SSOP-20_3.9x8.7mm_P0.635mm': Params(
+        #
+        # SSOP20: plastic shrink small outline package; 24 leads; body width 3.9 mm; lead pitch 0.635; (see http://www.ftdichip.com/Support/Documents/DataSheets/ICs/DS_FT231X.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SSOP-20_3.9x8.7mm_P0.635mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 8.7,         # body length
+        E1 = 3.9,         # body width
+        E = 6.2,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.25,          # pin width
+        e = 0.64,          # pin (center-to-center) distance
+        npx = 10,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SSOP-20_3.9x8.7mm_P0.635mm',            # modelName
+        modelName = 'SSOP-20_3.9x8.7mm_P0.635mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SSOP-28_3.9x9.9mm_P0.635mm': Params(
+        #
+        # SSOP28: plastic shrink small outline package; 28 leads; body width 3.9 mm; lead pitch 0.635; (see http://cds.linear.com/docs/en/datasheet/38901fb.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SSOP-28_3.9x9.9mm_P0.635mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 9.9,         # body length
+        E1 = 3.9,         # body width
+        E = 6.2,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.25,          # pin width
+        e = 0.64,          # pin (center-to-center) distance
+        npx = 14,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SSOP-28_3.9x9.9mm_P0.635mm',            # modelName
+        modelName = 'SSOP-28_3.9x9.9mm_P0.635mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SSOP-32_11.305x20.495mm_P1.27mm': Params(
+        #
+        # SSOP, 32 Pin (http://www.issi.com/WW/pdf/61-64C5128AL.pdf), generated with kicad-footprint-generator ipc_gullwing_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SSOP-32_11.305x20.495mm_P1.27mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 20.5,         # body length
+        E1 = 11.3,         # body width
+        E = 14.1,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.42,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 16,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SSOP-32_11.305x20.495mm_P1.27mm',            # modelName
+        modelName = 'SSOP-32_11.305x20.495mm_P1.27mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SSOP-44_5.3x12.8mm_P0.5mm': Params(
+        #
+        # 44-Lead Plastic Shrink Small Outline (SS)-5.30 mm Body [SSOP] (http://cds.linear.com/docs/en/datasheet/680313fa.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SSOP-44_5.3x12.8mm_P0.5mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 12.8,         # body length
+        E1 = 5.3,         # body width
+        E = 7.75,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.17,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 22,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SSOP-44_5.3x12.8mm_P0.5mm',            # modelName
+        modelName = 'SSOP-44_5.3x12.8mm_P0.5mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SSOP-8_3.9x5.05mm_P1.27mm': Params(
+        #
+        # SSOP, 8 Pin (http://www.fujitsu.com/downloads/MICRO/fsa/pdf/products/memory/fram/MB85RS16-DS501-00014-6v0-E.pdf), generated with kicad-footprint-generator ipc_gullwing_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SSOP-8_3.9x5.05mm_P1.27mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 5.05,         # body length
+        E1 = 3.9,         # body width
+        E = 6.35,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.42,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 4,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SSOP-8_3.9x5.05mm_P1.27mm',            # modelName
+        modelName = 'SSOP-8_3.9x5.05mm_P1.27mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'SSOP-8_5.25x5.24mm_P1.27mm': Params(
+        #
+        # SSOP, 8 Pin (http://www.fujitsu.com/ca/en/Images/MB85RS2MT-DS501-00023-1v0-E.pdf), generated with kicad-footprint-generator ipc_gullwing_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is SSOP-8_5.25x5.24mm_P1.27mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 5.24,         # body length
+        E1 = 5.25,         # body width
+        E = 8.22,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.42,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 4,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'SSOP-8_5.25x5.24mm_P1.27mm',            # modelName
+        modelName = 'SSOP-8_5.25x5.24mm_P1.27mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'ST_MultiPowerSO-30': Params(
+        #
+        # MultiPowerSO-30 3EP 16.0x17.2mm Pitch 1mm (http://www.st.com/resource/en/datasheet/vnh2sp30-e.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is ST_MultiPowerSO-30.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 17.4,         # body length
+        E1 = 16.0,         # body width
+        E = 18.25,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.5,          # pin width
+        e = 1.0,          # pin (center-to-center) distance
+        npx = 15,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'ST_MultiPowerSO-30',            # modelName
+        modelName = 'ST_MultiPowerSO-30',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'ST_PowerSSO-24_SlugDown': Params(
+        #
+        # ST PowerSSO-24 1EP 7.5x10.3mm Pitch 0.8mm [JEDEC MO-271] (http://www.st.com/resource/en/datasheet/tda7266p.pdf, http://freedatasheets.com/downloads/Technical%20Note%20Powersso24%20TN0054.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is ST_PowerSSO-24_SlugDown.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 10.3,         # body length
+        E1 = 7.5,         # body width
+        E = 9.87,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.3,          # pin width
+        e = 0.8,          # pin (center-to-center) distance
+        npx = 12,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'ST_PowerSSO-24_SlugDown',            # modelName
+        modelName = 'ST_PowerSSO-24_SlugDown',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'ST_PowerSSO-24_SlugUp': Params(
+        #
+        # ST PowerSSO-24 1EP 7.5x10.3mm Pitch 0.8mm [JEDEC MO-271] (http://www.st.com/resource/en/datasheet/tda7266p.pdf, http://freedatasheets.com/downloads/Technical%20Note%20Powersso24%20TN0054.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is ST_PowerSSO-24_SlugUp.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 10.3,         # body length
+        E1 = 7.5,         # body width
+        E = 9.87,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.3,          # pin width
+        e = 0.8,          # pin (center-to-center) distance
+        npx = 12,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'ST_PowerSSO-24_SlugUp',            # modelName
+        modelName = 'ST_PowerSSO-24_SlugUp',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'ST_PowerSSO-36_SlugDown': Params(
+        #
+        # ST PowerSSO-36 1EP 7.5x10.3mm Pitch 0.8mm [JEDEC MO-271] (http://www.st.com/resource/en/datasheet/tda7492p.pdf, http://freedatasheets.com/downloads/Technical%20Note%20Powersso24%20TN0054.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is ST_PowerSSO-36_SlugDown.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 10.3,         # body length
+        E1 = 7.5,         # body width
+        E = 9.87,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.2,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 18,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'ST_PowerSSO-36_SlugDown',            # modelName
+        modelName = 'ST_PowerSSO-36_SlugDown',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'ST_PowerSSO-36_SlugUp': Params(
+        #
+        # ST PowerSSO-36 1EP 7.5x10.3mm Pitch 0.8mm [JEDEC MO-271] (http://www.st.com/resource/en/datasheet/tda7492p.pdf, http://freedatasheets.com/downloads/Technical%20Note%20Powersso24%20TN0054.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is ST_PowerSSO-36_SlugUp.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 10.3,         # body length
+        E1 = 7.5,         # body width
+        E = 9.87,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.2,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 18,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'ST_PowerSSO-36_SlugUp',            # modelName
+        modelName = 'ST_PowerSSO-36_SlugUp',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'HTSOP-8-1EP_3.9x4.9mm_Pitch1.27mm': Params(
+        #
+        # Texas Instruments HSOP 9, 1.27mm pitch, 3.9x4.9mm body, exposed pad, DDA0008J (http://www.ti.com/lit/ds/symlink/tps5430.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is Texas_HSOP-8-1EP_3.9x4.9mm_P1.27mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 4.9,         # body length
+        E1 = 3.9,         # body width
+        E = 5.4,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.5,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 4,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'HTSOP-8-1EP_3.9x4.9mm_Pitch1.27mm',            # modelName
+        modelName = 'HTSOP-8-1EP_3.9x4.9mm_Pitch1.27mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'Texas_HTSOP-8-1EP_3.9x4.9mm_P1.27mm_EP2.85x4.9mm_Mask2.4x3.1mm_ThermalVias': Params(
+        #
+        # 8-pin HTSOP package with 1.27mm pin pitch, compatible with SOIC-8, 3.9x4.9mm body, exposed pad, thermal vias, http://www.ti.com/lit/ds/symlink/drv8870.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is Texas_HTSOP-8-1EP_3.9x4.9mm_P1.27mm_EP2.95x4.9mm_Mask2.4x3.1mm_ThermalVias.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 4.9,         # body length
+        E1 = 3.9,         # body width
+        E = 5.75,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.4,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 4,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'Texas_HTSOP-8-1EP_3.9x4.9mm_P1.27mm_EP2.85x4.9mm_Mask2.4x3.1mm_ThermalVias',            # modelName
+        modelName = 'Texas_HTSOP-8-1EP_3.9x4.9mm_P1.27mm_EP2.85x4.9mm_Mask2.4x3.1mm_ThermalVias',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'Texas_PWP0020A': Params(
+        #
+        # 20-Pin Thermally Enhanced Thin Shrink Small-Outline Package, Body 4.4x6.5x1.1mm, Pad 3.0x4.2mm, Texas Instruments (see http://www.ti.com/lit/ds/symlink/lm5118.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is Texas_PWP0020A.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 6.5,         # body length
+        E1 = 4.4,         # body width
+        E = 5.94,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.2,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 10,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'Texas_PWP0020A',            # modelName
+        modelName = 'Texas_PWP0020A',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TI_SO-PowerPAD-8': Params(
+        #
+        # 8-Lead Plastic PSOP, Exposed Die Pad (TI DDA0008B, see http://www.ti.com/lit/ds/symlink/lm3404.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TI_SO-PowerPAD-8.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.2,        # first pin indicator radius
+        fp_d = 0.3,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 4.9,         # body length
+        E1 = 3.9,         # body width
+        E = 5.4,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.5,          # pin width
+        e = 1.27,          # pin (center-to-center) distance
+        npx = 4,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TI_SO-PowerPAD-8',            # modelName
+        modelName = 'TI_SO-PowerPAD-8',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TSOP-5_1.65x3.05mm_P0.95mm': Params(
+        #
+        # TSOP-5 package (comparable to TSOT-23), https://www.vishay.com/docs/71200/71200.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TSOP-5_1.65x3.05mm_P0.95mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.1,        # first pin indicator radius
+        fp_d = 0.05,       # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 3.05,         # body length
+        E1 = 1.65,         # body width
+        E = 2.8,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.4,          # pin width
+        e = 0.95,          # pin (center-to-center) distance
+        npx = 3,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = [5],          # pin excluded
+        old_modelName = 'TSOP-5_1.65x3.05mm_P0.95mm',            # modelName
+        modelName = 'TSOP-5_1.65x3.05mm_P0.95mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TSOP-6_1.65x3.05mm_P0.95mm': Params(
+        #
+        # TSOP-6 package (comparable to TSOT-23), https://www.vishay.com/docs/71200/71200.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TSOP-6_1.65x3.05mm_P0.95mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.1,        # first pin indicator radius
+        fp_d = 0.05,       # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 3.05,         # body length
+        E1 = 1.65,         # body width
+        E = 2.8,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.0,          # body height
+        b = 0.4,          # pin width
+        e = 0.95,          # pin (center-to-center) distance
+        npx = 3,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TSOP-6_1.65x3.05mm_P0.95mm',            # modelName
+        modelName = 'TSOP-6_1.65x3.05mm_P0.95mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TSOP-I-28_11.8x8mm_P0.55mm': Params(
+        #
+        # TSOP I, 28 pins, 18.8x8mm body, 0.55mm pitch, IPC-calculated pads (http://ww1.microchip.com/downloads/en/devicedoc/doc0807.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TSOP-I-28_11.8x8mm_P0.55mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 8.0,         # body length
+        E1 = 11.8,         # body width
+        E = 13.2,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.2,          # pin width
+        e = 0.55,          # pin (center-to-center) distance
+        npx = 14,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TSOP-I-28_11.8x8mm_P0.55mm',            # modelName
+        modelName = 'TSOP-I-28_11.8x8mm_P0.55mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TSOP-I-32_11.8x8mm_P0.5mm': Params(
+        #
+        # TSOP-I, 32 Pin (http://www.issi.com/WW/pdf/61-64C5128AL.pdf), generated with kicad-footprint-generator ipc_gullwing_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TSOP-I-32_11.8x8mm_P0.5mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 8.0,         # body length
+        E1 = 11.8,         # body width
+        E = 13.2,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.2,          # pin width
+        e = 0.55,          # pin (center-to-center) distance
+        npx = 14,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TSOP-I-32_11.8x8mm_P0.5mm',            # modelName
+        modelName = 'TSOP-I-32_11.8x8mm_P0.5mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TSOP-I-32_18.4x8mm_P0.5mm': Params(
+        #
+        # TSOP I, 32 pins, 18.4x8mm body (https://www.micron.com/~/media/documents/products/technical-note/nor-flash/tn1225_land_pad_design.pdf, http://www.fujitsu.com/downloads/MICRO/fma/pdfmcu/f32pm25.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TSOP-I-32_18.4x8mm_P0.5mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 8.0,         # body length
+        E1 = 18.4,         # body width
+        E = 20.5,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.17,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 16,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TSOP-I-32_18.4x8mm_P0.5mm',            # modelName
+        modelName = 'TSOP-I-32_18.4x8mm_P0.5mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TSOP-I-48_18.4x12mm_P0.5mm': Params(
+        #
+        # TSOP I, 32 pins, 18.4x8mm body (https://www.micron.com/~/media/documents/products/technical-note/nor-flash/tn1225_land_pad_design.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TSOP-I-48_18.4x12mm_P0.5mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 12.0,         # body length
+        E1 = 18.4,         # body width
+        E = 20.5,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.17,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 24,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TSOP-I-48_18.4x12mm_P0.5mm',            # modelName
+        modelName = 'TSOP-I-48_18.4x12mm_P0.5mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TSOP-I-56_18.4x14mm_P0.5mm': Params(
+        #
+        # TSOP I, 32 pins, 18.4x8mm body (https://www.micron.com/~/media/documents/products/technical-note/nor-flash/tn1225_land_pad_design.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TSOP-I-56_18.4x14mm_P0.5mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 14.0,         # body length
+        E1 = 18.4,         # body width
+        E = 20.5,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.17,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 28,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TSOP-I-56_18.4x14mm_P0.5mm',            # modelName
+        modelName = 'TSOP-I-56_18.4x14mm_P0.5mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TSOP-II-44_10.16x18.41mm_P0.8mm': Params(
+        #
+        # TSOP-II, 44 Pin (http://www.issi.com/WW/pdf/61-64C5128AL.pdf), generated with kicad-footprint-generator ipc_gullwing_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TSOP-II-44_10.16x18.41mm_P0.8mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 18.41,         # body length
+        E1 = 10.16,         # body width
+        E = 11.66,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.25,          # pin width
+        e = 0.8,          # pin (center-to-center) distance
+        npx = 22,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TSOP-II-44_10.16x18.41mm_P0.8mm',            # modelName
+        modelName = 'TSOP-II-44_10.16x18.41mm_P0.8mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TSOP-II-54_22.2x10.16mm_P0.8mm': Params(
+        #
+        # 54-lead TSOP typ II package
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TSOP-II-54_22.2x10.16mm_P0.8mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 22.2,         # body length
+        E1 = 10.16,         # body width
+        E = 11.66,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.25,          # pin width
+        e = 0.8,          # pin (center-to-center) distance
+        npx = 27,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TSOP-II-54_22.2x10.16mm_P0.8mm',            # modelName
+        modelName = 'TSOP-II-54_22.2x10.16mm_P0.8mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TSSOP-14-1EP_4.4x5mm_P0.65mm': Params(
+        #
+        # 14-Lead Plastic Thin Shrink Small Outline (ST)-4.4 mm Body [TSSOP] with exposed pad (http://cds.linear.com/docs/en/datasheet/34301fa.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TSSOP-14-1EP_4.4x5mm_P0.65mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 4.5,         # body length
+        E1 = 4.4,         # body width
+        E = 5.5,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.25,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 7,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TSSOP-14-1EP_4.4x5mm_P0.65mm',            # modelName
+        modelName = 'TSSOP-14-1EP_4.4x5mm_P0.65mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TSSOP-28_4.4x9.7mm_Pitch0.65mm': Params(
+        #
+        # TSSOP28: plastic thin shrink small outline package; 28 leads; body width 4.4 mm; Exposed Pad Variation; (see NXP SSOP-TSSOP-VSO-REFLOW.pdf and sot361-1_po.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TSSOP-28-1EP_4.4x9.7mm_P0.65mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 9.7,         # body length
+        E1 = 4.4,         # body width
+        E = 5.5,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.25,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 14,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TSSOP-28_4.4x9.7mm_Pitch0.65mm',            # modelName
+        modelName = 'TSSOP-28_4.4x9.7mm_Pitch0.65mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TSSOP-30_4.4x7.8mm_P0.5mm': Params(
+        #
+        # TSSOP30: plastic thin shrink small outline package; 30 leads; body width 4.4 mm (http://www.ti.com/lit/ds/symlink/bq78350.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TSSOP-30_4.4x7.8mm_P0.5mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 7.8,         # body length
+        E1 = 4.4,         # body width
+        E = 6.7,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.2,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 15,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TSSOP-30_4.4x7.8mm_P0.5mm',            # modelName
+        modelName = 'TSSOP-30_4.4x7.8mm_P0.5mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TSSOP-38_6.1x12.5mm_P0.65mm': Params(
+        #
+        # TSSOP38: plastic thin shrink small outline package; 38 leads; body width 6.1 mm (http://www.ti.com/lit/ds/symlink/msp430g2744.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TSSOP-38_6.1x12.5mm_P0.65mm.kicad_mod
+        # 
+        the = 9.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.65,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.05,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 12.5,         # body length
+        E1 = 6.1,         # body width
+        E = 8.4,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.21,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 19,           # number of pins along X axis (width)
+        npy = 0,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TSSOP-38_6.1x12.5mm_P0.65mm',            # modelName
+        modelName = 'TSSOP-38_6.1x12.5mm_P0.65mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
 }


### PR DESCRIPTION
This push consist of 63 3D models for SOIC foot prints.

This push also include the script FindMissingSOIC3DModels.py that makes the comparision and creation of missing 3D models

The ordinary cq_paramters.py have been updated by a separate script and all 3D models can be recreated.

The script first find missing 3D models based on the parameter **model** in the foot print file.
Then it exctract the size , pitch and perhaps an epad from the foot print file name.
After that it extract the description and the pads from within the foot print file and finally add entries to the cq_parameter file.

It will assume some parameters such as the height and distance from pcb to body, the height is changed in 3 steps depednign of how large the body is.

I guess we have to trust the models and change those which we discover later that are wrong.
Can not expect to review all 63.

3D model push

3D model script push


Here is a couple examples of the generated models

![bild](https://user-images.githubusercontent.com/25547797/47957338-53553300-dfb4-11e8-9587-9aeff2ba50dc.png)

![bild](https://user-images.githubusercontent.com/25547797/47957342-5819e700-dfb4-11e8-9e28-c041a7207e74.png)

![bild](https://user-images.githubusercontent.com/25547797/47957344-5cde9b00-dfb4-11e8-94c0-7fe43e11bbeb.png)

![bild](https://user-images.githubusercontent.com/25547797/47957348-623be580-dfb4-11e8-9403-840ef084e34b.png)

