### PR TITLE
Added auto generated 23 QFP 3D models

### DIFF
--- a/cadquery/FCAD_script_generator/GW_QFP_SOIC_SSOP_TSSOP_SOT/FindMissingQFP3DModels.py
+++ b/cadquery/FCAD_script_generator/GW_QFP_SOIC_SSOP_TSSOP_SOT/FindMissingQFP3DModels.py
@@ -1,0 +1,584 @@
+#
+#
+# Auto create SSOP 3D models     version 1.0
+#
+# Script to scan SOIC foot print files and create 3D model paramters for those 3D models that 
+# is missing in \Package_QFP.3dshapes
+#
+# This script scan all the foot print files , extract the 3D models file name 
+# and check if the specified 3D model exists, if not, the script will create 
+# the paramters for the 3D model in a cq_paramter.py file style.
+# 
+# It will assume different height of the package depedning on the body size
+# It will assume the distance between the PCB and the body to 0.1 mm
+#
+# The script will use two different list, ExcludeModels and SpecialModels
+#
+# ExcludeModels list
+# If a foot print file name is in the ExcludeModels list it will be ignored 
+# For example the model is to complicated and need to be hand made or missing information 
+# so the data sheet nmust be consulted manually 
+#
+# SpecialModels list
+# If a 3D model name is in the SpecialModels list it will created with the paramters given 
+# in the list regardless what it says in the foot print file
+# For example the model is to complicated and need to be hand made or missing information 
+# so the data sheet nmust be consulted manually 
+#
+# It will scan the FP file to find the desired name of the 3D model name
+# It will scan the foot print file name to exctract body size, pad distance and, if present, 
+# the epad size.
+#
+# The script will create two files MakeFindMissingXXX3DModels.sh and MissingXXX3DModels.txt
+#
+# MissingXXX3DModels.txt
+# This file contain the content that should be appended to the ordinary cq_paramets.py file
+#
+# MakeFindMissingXXX3DModels.sh
+# This batch file contain one line for each missing model, it will start FreeCad 
+# with main_generator.py and the missing model as an argument.
+#
+# How to use this script
+# 1)
+# Execute this script like this 
+# python FindMissingXXX3DModels.py
+# 
+# 2)
+# append the content in MissingXXX3DModels.txt to cq_paramets.py
+#
+# 3)
+# execute the MakeFindMissingXXXDModels.sh so all the 3D models is created with help of FreeCad
+# ./MakeFindMissingXXX3DModels.sh
+#
+
+import sys
+import math
+import os
+import subprocess 
+import time
+import datetime
+from datetime import datetime as dt
+import re
+from pathlib import Path
+
+DefaultA1 = 0.1
+DefaultA =  1.0
+Defaultm =  0.0
+Defaultb =  0.2
+
+
+#
+# The path to foot print file directory in relation to where this script is placed
+#
+FPDir = '../../../../kicad-footprints/Package_QFP.pretty'
+KISYS3DMOD = '../../../../kicad-packages3D'
+
+#
+# The name of the result files
+#
+ResultFile = 'MissingQFP3DModels.txt'
+MakeAllfile = 'MakeFindMissingQFP3DModels.sh'
+#
+# The path to FreeCad, this path will be used in the MakeFindMissingXXX3DModels.sh script
+#
+FreeCadExe = '/c/users/stefan/Downloads/FreeCAD_0.17.11223_x64_dev_win/FreeCAD_0.17.11223_x64_dev_win/bin/FreeCAD.exe'
+MainGenerator = 'main_generator.py'
+
+
+MissingModels = []
+
+#
+# If a foot print file name is in the ExcludeModels list it will not be created
+#
+ExcludeModels =[
+#                    'Infineon_PQFN-22-15-4EP_6x5mm_P0.65mm.kicad_mod', 
+                ]
+
+#
+# If a foot print file contian a model name (xxxx.wrl) that is in the SpecialModels list 
+# it will will be created with those parameters given in the list
+#
+# model, D1, E1, E, e, b, npx, npy, excluded_pins
+#
+SpecialModels =[
+#                ['MSOP-12-16-1EP_3x4mm_P0.5mm_EP1.65x2.85mm',                   3.0,  4.00,  4.40,  0.50,  0.200,   0,  16,   "[2, 4, 13, 15]"],
+                ]
+                
+
+       
+                
+                
+class A3Dmodel:
+
+    def __init__(self, subf, currfile):
+    
+        self.subf = subf
+        self.currfile = currfile
+
+        self.the = 12.0      # body angle in degrees
+        self.tb_s = 0.15     # top part of body is that much smaller
+        self.c = 0.1         # pin thickness, body center part height
+        self.R1 = 0.1        # pin upper corner, inner radius
+        self.R2 = 0.1        # pin lower corner, inner radius
+        self.S = 0.10        # pin top flat part length (excluding corner arc)
+        self.L = 0.60        # pin bottom flat part length (including corner arc)
+        self.fp_s = True     # True for circular pinmark, False for square pinmark (useful for diodes)
+        self.fp_r = 0.5      # first pin indicator radius
+        self.fp_d = 0.20     # first pin indicator distance from edge
+        self.fp_z = 0.10     # first pin indicator depth
+        self.ef = 0.0        # fillet of edges  Note: bigger bytes model with fillet
+        self.cc1 = 0.25      # 0.45 chamfer of the 1st pin corner
+        self.D1 = 0.0        # body length
+        self.E1 = 0.0        # body width
+        self.E =  0.0        # body overall width
+        self.A1 = 0.1        # body-board separation
+        self.A2 = 0.0        # body height
+        self.b = 0.0         # pin width
+        self.e = 0.0         # pin (center-to-center) distance
+        self.npx = 0         # number of pins along X axis (width)
+        self.npy = 0         # number of pins along y axis (length)
+        self.epad = 'None'   # e Pad
+        self.excluded_pins = 'None' #no pin excluded
+        self.old_modelName = ''    #modelName
+        self.modelName = '' #modelName
+        self.rotation = -90   # rotation if required
+        self.numpin = 0
+        
+        
+    #
+    # Print the module on stdout, for debuging purpose
+    #
+    def Print(self):
+        print("self.subf          " + self.subf)
+        print("self.currfile      " + self.currfile)
+        print("self.D1              " + self.D1)
+        print("self.E1              " + self.E1)
+        print("self.E               " + self.E)
+        print("self.A1              " + self.A1)
+        print("self.A2              " + self.A2)
+        print("self.b               " + self.b)
+        print("self.e               " + self.e)
+        print("self.npx             " + self.npx)
+        print("self.npy             " + self.npy)
+        print("self.epad            " + self.epad)
+        print("self.excluded_pins   " + self.excluded_pins)
+        
+    #
+    # Scan and extract information from the foot print file
+    #
+    def ReadFile(self):
+        
+
+        #
+        # Extract what is possible from the model name
+        #
+#        print("self.subf " + self.subf)
+        li0 = self.subf.replace("_Pad", "_XXX")
+        li2 = li0.replace("_PullBack", "_XXX")
+        li3 = li2.replace("_PQFN", "_XXX")
+        li0 = li3.replace("_Pitch", "_P")
+        li1 = li0.replace("Linear_MSOP-", "Linear-MSOP-")
+        #
+        # Extract pitch
+        #
+        FoundPitch = False
+        if '_P' in li1:
+            spline = li1.split('_P')
+            spline2 = spline[1].split('mm')
+            try:
+                self.e = float(spline2[0])
+                FoundPitch = True
+            except ValueError:
+                print("_P in file name is wrong, skipping " + self.subf)
+                return False
+        else:
+            print("_P dont exist in file name, skipping add to exclude or special list " + self.subf)
+            return False
+        
+        #
+        # Extract body size, 
+        # trying to extract 11.0x15.9mm from HSOP-20-1EP_11.0x15.9mm_P1.27mm_SlugDown
+        #
+        FoundSize = False
+        spline = li1.split('_')
+        spline1 = spline[1].split('mm')
+        spline2 = spline1[0].split('x')
+        if len(spline2) == 2:
+            try:
+                self.E1 = float(spline2[0])
+            except ValueError:
+                print("First parameter in body size parameter in file name is wrong, skipping " + self.subf)
+                return False
+            try:
+                self.D1 = float(spline2[1])
+                FoundSize = True
+            except ValueError:
+                print("Second parameter in body size parameter in file name is wrong, skipping " + self.subf)
+                return False
+            
+        else:
+            print("size is 1 or more than 2 parameters, skipping, add to exclude or special list " + self.subf)
+            return False
+        
+#        print("E1, D1 " + str(self.E1), str(self.D1))
+        #
+        # Extract epad size
+        # trying to extract 3.4x6.5mm from HTSSOP-20-1EP_4.4x6.5mm_P0.65mm_EP3.4x6.5mm.kicad_mod
+        #
+        FoundEPad = False
+        self.epad = 'None'
+        if '_EP' in li1:
+            spline = li1.split('_EP')
+            spline2 = spline[1].split('mm')
+            spline3 = spline2[0].split('x')
+            EPadx = 0.0
+            if len(spline3) == 2:
+                try:
+                    EPadx = float(spline3[0])
+                except ValueError:
+                    print("first EPad parameter in file name is wrong, skipping " + self.subf)
+                    return False
+                try:
+                    EPady = float(spline3[1])
+                    if EPady > (self.D1 - 0.5):
+                        EPady = self.D1 - 0.5
+                        if EPady < 0.3:
+                            EPady = 0.2
+                    self.epad = '(' + str(EPady) + ', ' + str(round(EPadx, 2)) + ')'
+                    FoundEPad = True
+                except ValueError:
+                    print("Second EPad parameter in file name is wrong, skipping " + self.subf)
+                    return False
+                
+            else:
+                print("EPad parameter is 1 or more than 2 parameters, skipping, add to exclude or special list " + self.subf)
+                return False
+        
+#        print("epad " + self.epad)
+        #
+        # Extract number of pins
+        # trying to extract 20 from HTSSOP-20-1EP_4.4x6.5mm_P0.65mm_EP3.4x6.5mm.kicad_mod
+        #
+        FoundPinNum = False
+        self.numpin = 0
+        spline = li1.split('_')
+        spline1 = spline[0].split('-')
+        li1 = spline1[len(spline1) - 1]
+        try:
+            if li1 == '1EP':
+                li1 = spline1[len(spline1) - 2]
+                
+            self.numpin = int(li1)
+            FoundPinNum = True
+        except ValueError:
+            print("Pin number is missing in file name, skipping, add to exclude or special list " + self.subf)
+            return False
+
+#        print("self.numpin " + str(self.numpin))
+        PinPos = []
+        #
+        # Collect all pads to calculte npx and npy
+        #
+        minx = 0.0
+        maxx = 0.0
+        
+        with open(self.currfile) as currf:
+            for line in currf:
+                #
+                if 'pad' in line and ('layers F.Cu F.Paste F.Mask' in line or 'layers F.Cu F.Mask F.Paste' in line) and 'at' in line:
+                    spline = line.split('at ')
+                    spline2 = spline[1].split(')')
+                    spline3 = spline2[0].split(' ')
+                    x = float(spline3[0])
+                    y = float(spline3[1])
+                    minx = min(minx, x)
+                    maxx = max(maxx, x)
+                    PinMissing = True
+                    for i in range(len(PinPos)):
+                        if math.fabs(PinPos[i][0] - x) < 0.0001:
+                            PinMissing = False
+                            PinPos[i][2] = PinPos[i][2] + 1
+                    if PinMissing:
+                        PinPos.append([x, y, 1])
+
+                    spline = line.split('size ')
+                    spline2 = spline[1].split(')')
+                    spline3 = spline2[0].split(' ')
+                    w = float(spline3[0])
+                    h = float(spline3[1])
+                    self.b = round(h * 0.70, 2)
+                    if self.b > (self.e / 2.5):
+                        #
+                        # Pad is probably rotated
+                        #
+                        self.b = round(self.e / 2.5, 2)
+
+                    self.E = (maxx - minx) + 1.0
+#        for i in range(len(PinPos)):
+#            print("PinPos[" + str(i) + "] = " + str(PinPos[i][0]) + ", " + str(PinPos[i][1]) + ", " + str(PinPos[i][2]))
+
+        if len(PinPos) == 2:
+            #
+            # Only got pins along y-axis
+            #
+            if PinPos[0][2] == PinPos[1][2]:
+                self.npy = 0
+                self.npx = PinPos[0][2]
+            else:
+                print("Pads are unequal on left and right side, skipping, add to exclude or special list " + self.subf)
+                return False
+        else:
+            ssum = 0
+            hnum = 0
+            for i in range(len(PinPos)):
+                ssum = ssum + PinPos[i][2]
+                if PinPos[i][2] > hnum:
+                    hnum = PinPos[i][2]
+            #
+            if ssum == self.numpin:
+                #
+                # number of pads is equal to the number of found
+                #
+                self.npx = hnum
+                self.npy = int((self.numpin - (hnum + hnum)) / 2)
+            else:
+                print("Pads are missing, skipping, add to exclude or special list " + self.subf)
+                return False
+            
+            
+        if self.npx == 0 and self.npy == 0:
+            print("Could not calculte number of pads, skipping, add to exclude or special list " + self.subf)
+            sys.exit()
+            return False
+        
+        return True
+            
+    #
+    # Add a finnished 3D model to the ResultFile and MakeAllfile
+    #
+    def PrintMissingModels(self, datafile, commandfile):
+
+
+        
+        datafile.write("    '" + self.model + "': Params(\n")
+        datafile.write("        #\n")
+        datafile.write("        # " + self.descr + "\n")
+        datafile.write("        # This model have been auto generated based on the foot print file\n")
+        datafile.write("        # A number of paramters have been fixed or guessed, such as A2\n")
+        datafile.write("        # \n")
+        datafile.write("        # The foot print that uses this 3D model is " + self.subf + "\n")
+        datafile.write("        # \n")
+        datafile.write('        the = ' + str(round(self.the, 2)) + ',         # body angle in degrees\n')
+        datafile.write('        tb_s = ' + str(round(self.tb_s, 2)) + ',       # top part of body is that much smaller\n')
+        datafile.write('        c = ' + str(round(self.c, 2)) + ',           # pin thickness, body center part height\n')
+        datafile.write('        R1 = ' + str(round(self.R1, 2)) + ',          # pin upper corner, inner radius\n')
+        datafile.write('        R2 = ' + str(round(self.R2, 2)) + ',          # pin lower corner, inner radius\n')
+        datafile.write('        S  = ' + str(round(self.S, 2)) + ',          # pin top flat part length (excluding corner arc)\n')
+        datafile.write('#        L = ' + str(round(self.L, 2)) + ',         # pin bottom flat part length (including corner arc)\n')
+        datafile.write('        fp_s = ' + str(round(self.fp_s, 2)) + ',          # True for circular pinmark, False for square pinmark (useful for diodes)\n')
+
+        if self.D1 < 4.0 or self.E1 < 4.0:
+            if self.D1 < 2.0 or self.E1 < 2.0:
+                datafile.write("        fp_r = 0.1,        # first pin indicator radius\n")
+                datafile.write("        fp_d = 0.05,       # first pin indicator distance from edge\n")
+            else:
+                datafile.write("        fp_r = 0.2,        # first pin indicator radius\n")
+                datafile.write("        fp_d = 0.3,        # first pin indicator distance from edge\n")
+        else:
+            datafile.write("        fp_r = 0.4,        # first pin indicator radius\n")
+            datafile.write("        fp_d = 0.5,        # first pin indicator distance from edge\n")
+
+        datafile.write('        fp_z = ' + str(round(self.fp_z , 2)) + ',       # first pin indicator depth\n')
+        datafile.write('        ef = ' + str(round(self.ef, 2)) + ',          # fillet of edges  Note: bigger bytes model with fillet\n')
+        datafile.write('        cc1 = ' + str(round(self.cc1, 2)) + ',        # 0.45 chamfer of the 1st pin corner\n')
+        datafile.write('        D1 = ' + str(round(self.D1, 2)) + ',         # body length\n')
+        datafile.write('        E1 = ' + str(round(self.E1, 2)) + ',         # body width\n')
+        datafile.write('        E = ' + str(round(self.E, 2)) + ',          # body overall width\n')
+        datafile.write('        A1 = ' + str(round(self.A1 , 2)) + ',          # body-board separation\n')
+
+        if self.D1 < 4.0 or self.E1 < 4.0:
+            datafile.write("        A2 = 1.0,          # body height\n")
+        else:
+            datafile.write("        A2 = 1.5,          # body height\n")
+
+        datafile.write('        b = ' + str(round(self.b, 2)) + ',          # pin width\n')
+        datafile.write('        e = ' + str(round(self.e, 2)) + ',          # pin (center-to-center) distance\n')
+        datafile.write('        npx = ' + str(round(self.npx, 2)) + ',           # number of pins along X axis (width)\n')
+        datafile.write('        npy = ' + str(round(self.npy, 2)) + ',           # number of pins along y axis (length)\n')
+        datafile.write('        epad = ' + self.epad + ',       # e Pad\n')
+        datafile.write('        excluded_pins = ' + str(self.excluded_pins) + ',          # pin excluded\n')
+        datafile.write("        old_modelName = '" + self.old_modelName + "',            # modelName\n")
+        datafile.write("        modelName = '" + self.modelName + "',            # modelName\n")
+        datafile.write('        rotation = ' + str(self.rotation) + ',      # rotation if required\n')
+        
+        datafile.write('        ),\n\n')
+
+        #
+        # Create the FreeCad command line
+        #
+        commandfile.write(FreeCadExe + ' ' + MainGenerator + '  model_filter=' + self.model + '\n')
+
+#
+# Check if a foot print file should be excluded form being scanned
+#
+def DoNotExcludeModel(subf):
+    #
+    # Shall the model be excluded based on it's name
+    #
+    for n in ExcludeModels:
+        if n == subf:
+            #
+            # Exclude this 3D model from creation
+            #
+            print("Is in exclude list " + subf);
+            return False
+    
+    return True
+
+        
+#
+# Check if a 3D model given in the foot print file is misisng in the 3D model directory
+#
+def ModelDoNotExist(subf, currfile, NewA3Dmodel):
+    #
+    # Shall the model be excluded becaouse it already exist
+    #
+    with open(currfile) as currf:
+        for line in currf:
+            #
+            if 'descr' in line:
+                spline = line. split('"')
+                if len(spline) > 1:
+                    if len(spline[1]) > 2:
+                        NewA3Dmodel.descr = spline[1]
+            #
+            if 'model' in line:
+                line2 = line.replace("\\", "/")
+                line3 = line2.replace("\r", "/")
+                line4 = line3.replace("\n", "/")
+                line2 = line4.replace("\t", "/")
+                spline = line2.split('/')
+                if len(spline) > 2:
+                    NewA3Dmodel.destdirprefix = spline[1]
+                    NewA3Dmodel.filename = spline[2]
+                    spline2 = spline[2].split('.wrl')
+                    NewA3Dmodel.model = spline2[0]
+                    NewA3Dmodel.modelName = NewA3Dmodel.model
+                    NewA3Dmodel.old_modelName = NewA3Dmodel.model
+                    #
+                    line2 = spline[1] + '/' + spline[2]
+                    Model3DFile = KISYS3DMOD + '/' + line2
+#                    print("Model3DFile " + Model3DFile);
+                    Model3DFilePath = Path(Model3DFile)
+                    if Model3DFilePath.exists():
+                        #
+                        # 3D model already exist
+                        #
+#                        print("3D model exist, skipping it    " + subf);
+                        return False
+#                    print("3D model do not exist  " + NewA3Dmodel.model)
+                else:
+                    print("Exclude  " + subf + "   Something fuzzy about 3D model name")
+                    return False
+    
+    return True
+
+        
+#
+# Check if a 3D model should be created from the SpecialModel list
+#
+def IsNotSpecialModel(NewA3Dmodel):
+    #
+    # Is it a special model that do not require parsing
+    #
+    for n in SpecialModels:
+        if n[0] == NewA3Dmodel.model:
+            #
+            # This model is special setup
+            # model, D1, E1, E, e, b, npx, npy, excluded_pins
+            NewA3Dmodel.E1 = n[1]
+            NewA3Dmodel.D1 = n[2]
+            NewA3Dmodel.E = n[3]
+            NewA3Dmodel.e = n[4]
+            NewA3Dmodel.b = n[5]
+            NewA3Dmodel.npy = n[6]
+            NewA3Dmodel.npx = n[7]
+            NewA3Dmodel.excluded_pins = n[8]
+#            print("Special  " + NewA3Dmodel.subf)
+            return False
+
+    return True
+    
+
+#
+# Find all missing models
+#
+def FindMissingModels():
+
+    #
+    print("Checking dir: " + FPDir)
+    currdir = FPDir
+    #
+    for subpath, subdirs, subfiles in os.walk(currdir):
+        for subf in subfiles:
+            if subf.endswith('.kicad_mod'):
+                currfile = os.path.join(subpath, subf)
+                #
+                NewA3Dmodel = A3Dmodel(subf, currfile)
+                #
+                # Shall the model be excluded based on it's name
+                #
+                AddMissing = DoNotExcludeModel(subf)
+
+                if AddMissing:
+                    #
+                    # Shall the model be excluded because it already exist
+                    #
+                    AddMissing = ModelDoNotExist(subf, currfile, NewA3Dmodel)
+                    
+                if AddMissing:
+                    #
+                    # Is it a special model
+                    #
+                    if IsNotSpecialModel(NewA3Dmodel):
+                        #
+                        # Parse the data file
+                        #
+                        AddMissing = NewA3Dmodel.ReadFile()
+                        
+                        
+                if AddMissing:
+                    for n in MissingModels:
+                        if n.model == NewA3Dmodel.model:
+                            AddMissing = False
+                    #
+                    if AddMissing:
+                        print("Creating " + NewA3Dmodel.model);
+                        MissingModels.append(NewA3Dmodel)
+#                    NewA3Dmodel.Print()
+
+
+def SaveMissingModels():
+
+    datafile = open(ResultFile, "w") 
+    commandfile = open(MakeAllfile, "w") 
+    
+    commandfile.write('#!/bin/sh\n\n')
+    
+    for n in MissingModels:
+        n.PrintMissingModels(datafile, commandfile)
+
+    datafile.close()
+    commandfile.close()
+
+    print("Add paramters in " + ResultFile + " to file cq_parameters_qfp.py")
+    
+
+def main(argv):
+
+    MissingModels = []
+    FindMissingModels()
+    SaveMissingModels()
+        
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/cadquery/FCAD_script_generator/GW_QFP_SOIC_SSOP_TSSOP_SOT/cq_parameters_qfp.py
+++ b/cadquery/FCAD_script_generator/GW_QFP_SOIC_SSOP_TSSOP_SOT/cq_parameters_qfp.py
@@ -1302,4 +1302,855 @@ part_params = {
         modelName = 'TQFP-144_20x20mm_P0.5mm', #modelName
         rotation = -90, # rotation if required
         ),
+    'TQFP-64_10x10mm_Pitch0.5mm_EP8x8mm': Params(
+        #
+        # 64-Lead Plastic Thin Quad Flatpack (PT) - 10x10x1 mm Body, 2.00 mm Footprint [HTQFP] thermal pad
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is HTQFP-64-1EP_10x10mm_P0.5mm_EP8x8mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 10.0,         # body length
+        E1 = 10.0,         # body width
+        E = 12.4,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.2,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 16,           # number of pins along X axis (width)
+        npy = 16,           # number of pins along y axis (length)
+        epad = (8.0, 8.0),       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TQFP-64_10x10mm_Pitch0.5mm_EP8x8mm',            # modelName
+        modelName = 'TQFP-64_10x10mm_Pitch0.5mm_EP8x8mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'LQFP-32-1EP_5x5mm_P0.5mm_EP3.45x3.45mm_EP3.45x3.45mm': Params(
+        #
+        # LQFP32: plastic low profile quad flat package; 32 leads; body 5 x 5 x 1.4 mm (see NXP sot401-1_fr.pdf and sot401-1_po.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is LQFP-32-1EP_5x5mm_P0.5mm_EP3.45x3.45mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 5.0,         # body length
+        E1 = 5.0,         # body width
+        E = 7.5,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.2,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 8,           # number of pins along X axis (width)
+        npy = 8,           # number of pins along y axis (length)
+        epad = (3.45, 3.45),       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'LQFP-32-1EP_5x5mm_P0.5mm_EP3.45x3.45mm_EP3.45x3.45mm',            # modelName
+        modelName = 'LQFP-32-1EP_5x5mm_P0.5mm_EP3.45x3.45mm_EP3.45x3.45mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'LQFP-48-1EP_7x7mm_P0.5mm_EP3.6x3.6mm': Params(
+        #
+        # LQFP, 48 Pin (http://www.analog.com/media/en/technical-documentation/data-sheets/LTC7810.pdf), generated with kicad-footprint-generator ipc_qfp_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is LQFP-48-1EP_7x7mm_P0.5mm_EP3.6x3.6mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 7.0,         # body length
+        E1 = 7.0,         # body width
+        E = 9.32,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.2,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 12,           # number of pins along X axis (width)
+        npy = 12,           # number of pins along y axis (length)
+        epad = (3.6, 3.6),       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'LQFP-48-1EP_7x7mm_P0.5mm_EP3.6x3.6mm',            # modelName
+        modelName = 'LQFP-48-1EP_7x7mm_P0.5mm_EP3.6x3.6mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'LQFP-80_10x10mm_P0.4mm': Params(
+        #
+        # LQFP80: plastic low profile quad flat package; 80 leads; body 10 x 10  mm (see Intersil q80.10x10.pdf and wiznet W5100_Datasheet_v1.2.7.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is LQFP-80_10x10mm_P0.4mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 10.0,         # body length
+        E1 = 10.0,         # body width
+        E = 12.3,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.16,          # pin width
+        e = 0.4,          # pin (center-to-center) distance
+        npx = 20,           # number of pins along X axis (width)
+        npy = 20,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'LQFP-80_10x10mm_P0.4mm',            # modelName
+        modelName = 'LQFP-80_10x10mm_P0.4mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'LQFP-80_14x14mm_P0.65mm': Params(
+        #
+        # 80-Lead Quad Flatpack, 14x14x1.6mm Body (http://www.analog.com/media/en/technical-documentation/data-sheets/AD9852.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is LQFP-80_14x14mm_P0.65mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 14.0,         # body length
+        E1 = 14.0,         # body width
+        E = 16.4,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.26,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 20,           # number of pins along X axis (width)
+        npy = 20,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'LQFP-80_14x14mm_P0.65mm',            # modelName
+        modelName = 'LQFP-80_14x14mm_P0.65mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'PQFP-112_20x20mm_P0.65mm': Params(
+        #
+        # PQFP, 112 pins, 20mm sq body, 0.65mm pitch (http://cache.freescale.com/files/shared/doc/package_info/98ASS23330W.pdf, http://www.nxp.com/docs/en/application-note/AN4388.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is PQFP-112_20x20mm_P0.65mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 20.0,         # body length
+        E1 = 20.0,         # body width
+        E = 22.5,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.26,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 28,           # number of pins along X axis (width)
+        npy = 28,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'PQFP-112_20x20mm_P0.65mm',            # modelName
+        modelName = 'PQFP-112_20x20mm_P0.65mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'PQFP-132_24x24mm_P0.635mm': Params(
+        #
+        # PQFP, 132 pins, 24mm sq body, 0.635mm pitch (https://www.intel.com/content/dam/www/public/us/en/documents/packaging-databooks/packaging-chapter-02-databook.pdf, http://www.nxp.com/docs/en/application-note/AN4388.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is PQFP-132_24x24mm_P0.635mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 24.0,         # body length
+        E1 = 24.0,         # body width
+        E = 27.8,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.25,          # pin width
+        e = 0.64,          # pin (center-to-center) distance
+        npx = 33,           # number of pins along X axis (width)
+        npy = 33,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'PQFP-132_24x24mm_P0.635mm',            # modelName
+        modelName = 'PQFP-132_24x24mm_P0.635mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'PQFP-132_24x24mm_P0.635mm_i386': Params(
+        #
+        # PQFP, 132 pins, 24mm sq body, 0.635mm pitch, Intel 386EX (https://www.intel.com/content/dam/www/public/us/en/documents/packaging-databooks/packaging-chapter-02-databook.pdf, http://www.nxp.com/docs/en/application-note/AN4388.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is PQFP-132_24x24mm_P0.635mm_i386.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 24.0,         # body length
+        E1 = 24.0,         # body width
+        E = 27.8,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.25,          # pin width
+        e = 0.64,          # pin (center-to-center) distance
+        npx = 33,           # number of pins along X axis (width)
+        npy = 33,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'PQFP-132_24x24mm_P0.635mm_i386',            # modelName
+        modelName = 'PQFP-132_24x24mm_P0.635mm_i386',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'PQFP-144_28x28mm_P0.65mm': Params(
+        #
+        # PQFP, 144 Pin (http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=131095), generated with kicad-footprint-generator ipc_qfp_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is PQFP-144_28x28mm_P0.65mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 28.0,         # body length
+        E1 = 28.0,         # body width
+        E = 31.25,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.26,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 36,           # number of pins along X axis (width)
+        npy = 36,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'PQFP-144_28x28mm_P0.65mm',            # modelName
+        modelName = 'PQFP-144_28x28mm_P0.65mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'PQFP-160_28x28mm_P0.65mm': Params(
+        #
+        # PQFP, 160 Pin (http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=131095), generated with kicad-footprint-generator ipc_qfp_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is PQFP-160_28x28mm_P0.65mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 28.0,         # body length
+        E1 = 28.0,         # body width
+        E = 31.25,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.26,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 40,           # number of pins along X axis (width)
+        npy = 40,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'PQFP-160_28x28mm_P0.65mm',            # modelName
+        modelName = 'PQFP-160_28x28mm_P0.65mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'PQFP-208_28x28mm_P0.5mm': Params(
+        #
+        # PQFP, 208 Pin (http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=131095), generated with kicad-footprint-generator ipc_qfp_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is PQFP-208_28x28mm_P0.5mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 28.0,         # body length
+        E1 = 28.0,         # body width
+        E = 30.93,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.2,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 52,           # number of pins along X axis (width)
+        npy = 52,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'PQFP-208_28x28mm_P0.5mm',            # modelName
+        modelName = 'PQFP-208_28x28mm_P0.5mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'PQFP-240_32.1x32.1mm_P0.5mm': Params(
+        #
+        # PQFP, 240 Pin (http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=131095), generated with kicad-footprint-generator ipc_qfp_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is PQFP-240_32.1x32.1mm_P0.5mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 32.1,         # body length
+        E1 = 32.1,         # body width
+        E = 34.92,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.2,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 60,           # number of pins along X axis (width)
+        npy = 60,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'PQFP-240_32.1x32.1mm_P0.5mm',            # modelName
+        modelName = 'PQFP-240_32.1x32.1mm_P0.5mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'PQFP-44_10x10mm_P0.8mm': Params(
+        #
+        # 44-Lead Plastic Quad Flatpack - 10x10x2.5mm Body (http://www.onsemi.com/pub/Collateral/122BK.PDF)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is PQFP-44_10x10mm_P0.8mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 10.0,         # body length
+        E1 = 10.0,         # body width
+        E = 13.1,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.32,          # pin width
+        e = 0.8,          # pin (center-to-center) distance
+        npx = 11,           # number of pins along X axis (width)
+        npy = 11,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'PQFP-44_10x10mm_P0.8mm',            # modelName
+        modelName = 'PQFP-44_10x10mm_P0.8mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TQFP-100_14x14mm_P0.5mm_EP5x5mm': Params(
+        #
+        # 100-Lead Plastic Thin Quad Flatpack (PF) - 14x14x1 mm Body 2.00 mm Footprint with Exposed Pad [TQFP] (see Microchip Packaging Specification 00000049BS.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TQFP-100-1EP_14x14mm_P0.5mm_EP5x5mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 14.0,         # body length
+        E1 = 14.0,         # body width
+        E = 16.4,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.2,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 25,           # number of pins along X axis (width)
+        npy = 25,           # number of pins along y axis (length)
+        epad = (5.0, 5.0),       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TQFP-100_14x14mm_P0.5mm_EP5x5mm',            # modelName
+        modelName = 'TQFP-100_14x14mm_P0.5mm_EP5x5mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TQFP-176_24x24mm_P0.5mm': Params(
+        #
+        # TQFP, 176 Pin (http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=131095), generated with kicad-footprint-generator ipc_qfp_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TQFP-176_24x24mm_P0.5mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 24.0,         # body length
+        E1 = 24.0,         # body width
+        E = 26.32,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.2,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 44,           # number of pins along X axis (width)
+        npy = 44,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TQFP-176_24x24mm_P0.5mm',            # modelName
+        modelName = 'TQFP-176_24x24mm_P0.5mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TQFP-48-1EP_7x7mm_P0.5mm_EP5x5mm': Params(
+        #
+        # TQFP, 48 Pin (https://www.trinamic.com/fileadmin/assets/Products/ICs_Documents/TMC2100_datasheet_Rev1.08.pdf (page 45)), generated with kicad-footprint-generator ipc_qfp_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TQFP-48-1EP_7x7mm_P0.5mm_EP5x5mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 7.0,         # body length
+        E1 = 7.0,         # body width
+        E = 9.32,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.2,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 12,           # number of pins along X axis (width)
+        npy = 12,           # number of pins along y axis (length)
+        epad = (5.0, 5.0),       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TQFP-48-1EP_7x7mm_P0.5mm_EP5x5mm',            # modelName
+        modelName = 'TQFP-48-1EP_7x7mm_P0.5mm_EP5x5mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TQFP-52-1EP_10x10mm_P0.65mm_EP6.5x6.5mm': Params(
+        #
+        # TQFP, 52 Pin (http://www.analog.com/media/en/package-pcb-resources/package/pkg_pdf/tqfp_edsv/sv_52_1.pdf), generated with kicad-footprint-generator ipc_qfp_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TQFP-52-1EP_10x10mm_P0.65mm_EP6.5x6.5mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 10.0,         # body length
+        E1 = 10.0,         # body width
+        E = 12.32,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.26,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 13,           # number of pins along X axis (width)
+        npy = 13,           # number of pins along y axis (length)
+        epad = (6.5, 6.5),       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TQFP-52-1EP_10x10mm_P0.65mm_EP6.5x6.5mm',            # modelName
+        modelName = 'TQFP-52-1EP_10x10mm_P0.65mm_EP6.5x6.5mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TQFP-64_10x10mm_P0.5mm_EP8x8mm': Params(
+        #
+        # 64-Lead Plastic Thin Quad Flatpack (PT) - 10x10x1 mm Body, 2.00 mm Footprint [TQFP] thermal pad
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TQFP-64-1EP_10x10mm_P0.5mm_EP8x8mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 10.0,         # body length
+        E1 = 10.0,         # body width
+        E = 12.4,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.2,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 16,           # number of pins along X axis (width)
+        npy = 16,           # number of pins along y axis (length)
+        epad = (8.0, 8.0),       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TQFP-64_10x10mm_P0.5mm_EP8x8mm',            # modelName
+        modelName = 'TQFP-64_10x10mm_P0.5mm_EP8x8mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'TQFP-80-1EP_14x14mm_P0.65mm_EP9.5x9.5mm': Params(
+        #
+        # 80-Lead Plastic Thin Quad Flatpack (PF) - 14x14mm body, 9.5mm sq thermal pad (http://www.analog.com/media/en/technical-documentation/data-sheets/AD9852.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is TQFP-80-1EP_14x14mm_P0.65mm_EP9.5x9.5mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 14.0,         # body length
+        E1 = 14.0,         # body width
+        E = 16.4,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.26,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 20,           # number of pins along X axis (width)
+        npy = 20,           # number of pins along y axis (length)
+        epad = (9.5, 9.5),       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'TQFP-80-1EP_14x14mm_P0.65mm_EP9.5x9.5mm',            # modelName
+        modelName = 'TQFP-80-1EP_14x14mm_P0.65mm_EP9.5x9.5mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'VQFP-100_14x14mm_P0.5mm': Params(
+        #
+        # VQFP, 100 Pin (http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=131095), generated with kicad-footprint-generator ipc_qfp_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is VQFP-100_14x14mm_P0.5mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 14.0,         # body length
+        E1 = 14.0,         # body width
+        E = 16.32,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.2,          # pin width
+        e = 0.5,          # pin (center-to-center) distance
+        npx = 25,           # number of pins along X axis (width)
+        npy = 25,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'VQFP-100_14x14mm_P0.5mm',            # modelName
+        modelName = 'VQFP-100_14x14mm_P0.5mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'VQFP-128_14x14mm_P0.4mm': Params(
+        #
+        # VQFP, 128 Pin (http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=131095), generated with kicad-footprint-generator ipc_qfp_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is VQFP-128_14x14mm_P0.4mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 14.0,         # body length
+        E1 = 14.0,         # body width
+        E = 16.32,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.16,          # pin width
+        e = 0.4,          # pin (center-to-center) distance
+        npx = 32,           # number of pins along X axis (width)
+        npy = 32,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'VQFP-128_14x14mm_P0.4mm',            # modelName
+        modelName = 'VQFP-128_14x14mm_P0.4mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'VQFP-176_20x20mm_P0.4mm': Params(
+        #
+        # VQFP, 176 Pin (http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=131095), generated with kicad-footprint-generator ipc_qfp_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is VQFP-176_20x20mm_P0.4mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 20.0,         # body length
+        E1 = 20.0,         # body width
+        E = 22.32,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.16,          # pin width
+        e = 0.4,          # pin (center-to-center) distance
+        npx = 44,           # number of pins along X axis (width)
+        npy = 44,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'VQFP-176_20x20mm_P0.4mm',            # modelName
+        modelName = 'VQFP-176_20x20mm_P0.4mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
+    'VQFP-80_14x14mm_P0.65mm': Params(
+        #
+        # VQFP, 80 Pin (http://www.microsemi.com/index.php?option=com_docman&task=doc_download&gid=131095), generated with kicad-footprint-generator ipc_qfp_generator.py
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A2
+        # 
+        # The foot print that uses this 3D model is VQFP-80_14x14mm_P0.65mm.kicad_mod
+        # 
+        the = 12.0,         # body angle in degrees
+        tb_s = 0.15,       # top part of body is that much smaller
+        c = 0.1,           # pin thickness, body center part height
+        R1 = 0.1,          # pin upper corner, inner radius
+        R2 = 0.1,          # pin lower corner, inner radius
+        S  = 0.1,          # pin top flat part length (excluding corner arc)
+#        L = 0.6,         # pin bottom flat part length (including corner arc)
+        fp_s = 1,          # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,        # first pin indicator radius
+        fp_d = 0.5,        # first pin indicator distance from edge
+        fp_z = 0.1,       # first pin indicator depth
+        ef = 0.0,          # fillet of edges  Note: bigger bytes model with fillet
+        cc1 = 0.25,        # 0.45 chamfer of the 1st pin corner
+        D1 = 14.0,         # body length
+        E1 = 14.0,         # body width
+        E = 16.32,          # body overall width
+        A1 = 0.1,          # body-board separation
+        A2 = 1.5,          # body height
+        b = 0.26,          # pin width
+        e = 0.65,          # pin (center-to-center) distance
+        npx = 20,           # number of pins along X axis (width)
+        npy = 20,           # number of pins along y axis (length)
+        epad = None,       # e Pad
+        excluded_pins = None,          # pin excluded
+        old_modelName = 'VQFP-80_14x14mm_P0.65mm',            # modelName
+        modelName = 'VQFP-80_14x14mm_P0.65mm',            # modelName
+        rotation = -90,      # rotation if required
+        ),
+
 }


### PR DESCRIPTION
This push consist of 23 3D models for QFD  foot prints.

This push also include the script FindMissingQFD3DModels.py that makes the comparison and creation of missing 3D models

The ordinary cq_parameters.py have been updated by a separate script and all 3D models can be recreated.

The script first find missing 3D models based on the parameter **model** in the foot print file.
Then it extract the size , pitch and perhaps an epad from the foot print file name.
After that it extract the description and the pads from within the foot print file and finally add entries to the cq_parameter file.

It will assume some parameters such as the height and distance from pcb to body, the height is changed in 3 steps depending of how large the body is.

I guess we have to trust the models and change those which we discover later that are wrong.
Can not expect to review all 23.

3D model push
https://github.com/KiCad/kicad-packages3D/pull/448

3D model script push
https://github.com/easyw/kicad-3d-models-in-freecad/pull/218

Here is a couple examples of the generated models

![bild](https://user-images.githubusercontent.com/25547797/47965825-29e7e600-e04c-11e8-8f0a-57b273ffb1be.png)

![bild](https://user-images.githubusercontent.com/25547797/47965826-2eac9a00-e04c-11e8-9dcb-7fa9ac975c9a.png)

![bild](https://user-images.githubusercontent.com/25547797/47965829-33714e00-e04c-11e8-9a0f-4e9c1160b19a.png)
