### PR TITLE
Added missing BGA 3D models

### DIFF
--- a/cadquery/FCAD_script_generator/BGA_packages/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/BGA_packages/cq_parameters.py
@@ -1202,4 +1202,676 @@ kicad_naming_params_qfn = {
         rotation = -90, # rotation if required
         dest_dir_prefix = '',
         ),
+    'BGA-153_8.0x8.0mm_Layout15x15_P0.5mm_Ball0.3mm_Pad0.25mm_NSMD': Params(
+        #
+        # Altera MBGA-153, https://www.altera.com/content/dam/altera-www/global/en_US/pdfs/literature/packaging/04r00471-00.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is BGA-153_8.0x8.0mm_Layout15x15_P0.5mm_Ball0.3mm_Pad0.25mm_NSMD.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 8.0,      # body overall length
+        E = 8.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.3,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.5,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 15,      # number of pins along X axis (width)
+        npy = 15,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'BGA-153_8.0x8.0mm_Layout15x15_P0.5mm_Ball0.3mm_Pad0.25mm_NSMD', # Old_modelName
+        modelName = 'BGA-153_8.0x8.0mm_Layout15x15_P0.5mm_Ball0.3mm_Pad0.25mm_NSMD',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'BGA-36_3.396x3.466mm_Layout6x6_P0.4mm_Ball0.25mm_Pad0.2mm_NSMD': Params(
+        #
+        # Altera V36, https://www.altera.com/content/dam/altera-www/global/en_US/pdfs/literature/packaging/04r00486-00.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is BGA-36_3.396x3.466mm_Layout6x6_P0.4mm_Ball0.25mm_Pad0.2mm_NSMD.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 3.466,      # body overall length
+        E = 3.396,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.25,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.4,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 6,      # number of pins along X axis (width)
+        npy = 6,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'BGA-36_3.396x3.466mm_Layout6x6_P0.4mm_Ball0.25mm_Pad0.2mm_NSMD', # Old_modelName
+        modelName = 'BGA-36_3.396x3.466mm_Layout6x6_P0.4mm_Ball0.25mm_Pad0.2mm_NSMD',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'BGA-672_27.0x27.0mm_Layout26x26_P1.0mm_Ball0.6mm_Pad0.5mm_NSMD': Params(
+        #
+        # Altera BGA-672, https://www.altera.com/content/dam/altera-www/global/en_US/pdfs/literature/packaging/04r00472-00.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is BGA-672_27.0x27.0mm_Layout26x26_P1.0mm_Ball0.6mm_Pad0.5mm_NSMD.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 27.0,      # body overall length
+        E = 27.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.6,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 1.0,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 26,      # number of pins along X axis (width)
+        npy = 26,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'BGA-672_27.0x27.0mm_Layout26x26_P1.0mm_Ball0.6mm_Pad0.5mm_NSMD', # Old_modelName
+        modelName = 'BGA-672_27.0x27.0mm_Layout26x26_P1.0mm_Ball0.6mm_Pad0.5mm_NSMD',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'BGA-676_27.0x27.0mm_Layout26x26_P1.0mm_Ball0.6mm_Pad0.5mm_NSMD': Params(
+        #
+        # XILINX BGA-676, https://www.xilinx.com/support/documentation/package_specs/fg676.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is BGA-676_27.0x27.0mm_Layout26x26_P1.0mm_Ball0.6mm_Pad0.5mm_NSMD.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 27.0,      # body overall length
+        E = 27.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.6,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 1.0,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 26,      # number of pins along X axis (width)
+        npy = 26,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'BGA-676_27.0x27.0mm_Layout26x26_P1.0mm_Ball0.6mm_Pad0.5mm_NSMD', # Old_modelName
+        modelName = 'BGA-676_27.0x27.0mm_Layout26x26_P1.0mm_Ball0.6mm_Pad0.5mm_NSMD',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'Texas_DSBGA-64_3.415x3.535mm_Layout8x8_P0.4mm': Params(
+        #
+        # Texas Instruments, DSBGA, 3.415x3.535x0.625mm, 64 ball 8x8 area grid, NSMD pad definition (http://www.ti.com/lit/ds/slas718g/slas718g.pdf, http://www.ti.com/lit/an/snva009ag/snva009ag.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is Texas_DSBGA-64_3.415x3.535mm_Layout8x8_P0.4mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 3.535,      # body overall length
+        E = 3.415,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.2,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.4,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 8,      # number of pins along X axis (width)
+        npy = 8,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'Texas_DSBGA-64_3.415x3.535mm_Layout8x8_P0.4mm', # Old_modelName
+        modelName = 'Texas_DSBGA-64_3.415x3.535mm_Layout8x8_P0.4mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'Texas_DSBGA-6_0.9x1.4mm_Layout2x3_P0.5mm': Params(
+        #
+        # Texas Instruments, DSBGA, 0.9x1.4mm, 6 bump 2x3 (perimeter) array, NSMD pad definition (http://www.ti.com/lit/ds/symlink/ts5a3159a.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is Texas_DSBGA-6_0.9x1.4mm_Layout2x3_P0.5mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.2,          # First pin indicator radius
+        fp_d = 0.1,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 1.4,      # body overall length
+        E = 0.94,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.25,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.5,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 3,      # number of pins along X axis (width)
+        npy = 2,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'Texas_DSBGA-6_0.9x1.4mm_Layout2x3_P0.5mm', # Old_modelName
+        modelName = 'Texas_DSBGA-6_0.9x1.4mm_Layout2x3_P0.5mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'Texas_DSBGA-8_1.43x1.41mm_Layout3x3_P0.5mm': Params(
+        #
+        # Texas Instruments, DSBGA, 1.43x1.41mm, 8 bump 3x3 (perimeter) array, NSMD pad definition (http://www.ti.com/lit/ds/symlink/lmc555.pdf, http://www.ti.com/lit/an/snva009ag/snva009ag.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is Texas_DSBGA-8_1.43x1.41mm_Layout3x3_P0.5mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.2,          # First pin indicator radius
+        fp_d = 0.1,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 1.43,      # body overall length
+        E = 1.41,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.25,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.5,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 3,      # number of pins along X axis (width)
+        npy = 3,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'Texas_DSBGA-8_1.43x1.41mm_Layout3x3_P0.5mm', # Old_modelName
+        modelName = 'Texas_DSBGA-8_1.43x1.41mm_Layout3x3_P0.5mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'Texas_DSBGA-9_1.4715x1.4715mm_Layout3x3_P0.5mm': Params(
+        #
+        # Texas Instruments, DSBGA, 1.4715x1.4715mm, 9 bump 3x3 array, NSMD pad definition (http://www.ti.com/lit/ds/symlink/lm4990.pdf, http://www.ti.com/lit/an/snva009ag/snva009ag.pdf)
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is Texas_DSBGA-9_1.4715x1.4715mm_Layout3x3_P0.5mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.2,          # First pin indicator radius
+        fp_d = 0.1,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 1.4715,      # body overall length
+        E = 1.4715,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.25,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.5,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 3,      # number of pins along X axis (width)
+        npy = 3,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'Texas_DSBGA-9_1.4715x1.4715mm_Layout3x3_P0.5mm', # Old_modelName
+        modelName = 'Texas_DSBGA-9_1.4715x1.4715mm_Layout3x3_P0.5mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'UCBGA-81_4x4mm_Layout9x9_P0.4mm': Params(
+        #
+        # UCBGA-81, 9x9 raster, 4x4mm package, pitch 0.4mm; https://www.latticesemi.com/view_document?document_id=213
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is UCBGA-81_4x4mm_Layout9x9_P0.4mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 4.0,      # body overall length
+        E = 4.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.2,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.4,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 9,      # number of pins along X axis (width)
+        npy = 9,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'UCBGA-81_4x4mm_Layout9x9_P0.4mm', # Old_modelName
+        modelName = 'UCBGA-81_4x4mm_Layout9x9_P0.4mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'UFBGA-100_7x7mm_Layout12x12_P0.5mm': Params(
+        #
+        # UFBGA-100, 12x12 raster, 7x7mm package, pitch 0.5mm; see section 7.1 of http://www.st.com/resource/en/datasheet/stm32f103tb.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is UFBGA-100_7x7mm_Layout12x12_P0.5mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 7.0,      # body overall length
+        E = 7.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.25,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.5,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 12,      # number of pins along X axis (width)
+        npy = 12,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'UFBGA-100_7x7mm_Layout12x12_P0.5mm', # Old_modelName
+        modelName = 'UFBGA-100_7x7mm_Layout12x12_P0.5mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'UFBGA-132_7x7mm_Layout12x12_P0.5mm': Params(
+        #
+        # UFBGA-132, 12x12 raster, 7x7mm package, pitch 0.5mm; see section 7.4 of http://www.st.com/resource/en/datasheet/stm32l152zc.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is UFBGA-132_7x7mm_Layout12x12_P0.5mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 7.0,      # body overall length
+        E = 7.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.25,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.5,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 12,      # number of pins along X axis (width)
+        npy = 12,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'UFBGA-132_7x7mm_Layout12x12_P0.5mm', # Old_modelName
+        modelName = 'UFBGA-132_7x7mm_Layout12x12_P0.5mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'UFBGA-132_7x7mm_P0.5mm': Params(
+        #
+        # UFBGA 132 Pins, 0.5mm Pitch, 0.3mm Ball, http://www.st.com/resource/en/datasheet/stm32l486qg.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is UFBGA-132_7x7mm_P0.5mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 7.0,      # body overall length
+        E = 7.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.25,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.5,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 11,      # number of pins along X axis (width)
+        npy = 11,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'UFBGA-132_7x7mm_P0.5mm', # Old_modelName
+        modelName = 'UFBGA-132_7x7mm_P0.5mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'UFBGA-144_10x10mm_Layout12x12_P0.8mm': Params(
+        #
+        # UFBGA-144, 12x12 raster, 10x10mm package, pitch 0.8mm; see section 7.5 of http://www.st.com/resource/en/datasheet/stm32f446ze.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is UFBGA-144_10x10mm_Layout12x12_P0.8mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 10.0,      # body overall length
+        E = 10.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.4,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.8,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 12,      # number of pins along X axis (width)
+        npy = 12,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'UFBGA-144_10x10mm_Layout12x12_P0.8mm', # Old_modelName
+        modelName = 'UFBGA-144_10x10mm_Layout12x12_P0.8mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'UFBGA-144_7x7mm_Layout12x12_P0.5mm': Params(
+        #
+        # UFBGA-144, 12x12 raster, 7x7mm package, pitch 0.5mm; see section 7.4 of http://www.st.com/resource/en/datasheet/stm32f446ze.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is UFBGA-144_7x7mm_Layout12x12_P0.5mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 7.0,      # body overall length
+        E = 7.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.25,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.5,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 12,      # number of pins along X axis (width)
+        npy = 12,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'UFBGA-144_7x7mm_Layout12x12_P0.5mm', # Old_modelName
+        modelName = 'UFBGA-144_7x7mm_Layout12x12_P0.5mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'UFBGA-15_3.0x3.0mm_Layout4x4_P0.65mm': Params(
+        #
+        # UFBGA-15, 4x4, 3x3mm package, pitch 0.65mm
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is UFBGA-15_3.0x3.0mm_Layout4x4_P0.65mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 3.0,      # body overall length
+        E = 3.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.325,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.65,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 4,      # number of pins along X axis (width)
+        npy = 4,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'UFBGA-15_3.0x3.0mm_Layout4x4_P0.65mm', # Old_modelName
+        modelName = 'UFBGA-15_3.0x3.0mm_Layout4x4_P0.65mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'UFBGA-169_7x7mm_Layout13x13_P0.5mm': Params(
+        #
+        # UFBGA-169, 13x13 raster, 7x7mm package, pitch 0.5mm; see section 7.6 of http://www.st.com/resource/en/datasheet/stm32f429ng.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is UFBGA-169_7x7mm_Layout13x13_P0.5mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 7.0,      # body overall length
+        E = 7.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.25,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.5,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 13,      # number of pins along X axis (width)
+        npy = 13,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'UFBGA-169_7x7mm_Layout13x13_P0.5mm', # Old_modelName
+        modelName = 'UFBGA-169_7x7mm_Layout13x13_P0.5mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'UFBGA-201_10x10mm_Layout15x15_P0.65mm': Params(
+        #
+        # UFBGA-201, 15x15 raster, 10x10mm package, pitch 0.65mm; see section 7.6 of http://www.st.com/resource/en/datasheet/stm32f207vg.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is UFBGA-201_10x10mm_Layout15x15_P0.65mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 10.0,      # body overall length
+        E = 10.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.325,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.65,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 15,      # number of pins along X axis (width)
+        npy = 15,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'UFBGA-201_10x10mm_Layout15x15_P0.65mm', # Old_modelName
+        modelName = 'UFBGA-201_10x10mm_Layout15x15_P0.65mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'UFBGA-32_4.0x4.0mm_Layout6x6_P0.5mm': Params(
+        #
+        # UFBGA-32, 6x6, 4x4mm package, pitch 0.5mm
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is UFBGA-32_4.0x4.0mm_Layout6x6_P0.5mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 4.0,      # body overall length
+        E = 4.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.25,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.5,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 6,      # number of pins along X axis (width)
+        npy = 6,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'UFBGA-32_4.0x4.0mm_Layout6x6_P0.5mm', # Old_modelName
+        modelName = 'UFBGA-32_4.0x4.0mm_Layout6x6_P0.5mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'UFBGA-64_5x5mm_Layout8x8_P0.5mm': Params(
+        #
+        # UFBGA-64, 8x8 raster, 5x5mm package, pitch 0.5mm; see section 7.1 of http://www.st.com/resource/en/datasheet/stm32f051t8.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is UFBGA-64_5x5mm_Layout8x8_P0.5mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 5.0,      # body overall length
+        E = 5.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.25,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.5,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 8,      # number of pins along X axis (width)
+        npy = 8,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'UFBGA-64_5x5mm_Layout8x8_P0.5mm', # Old_modelName
+        modelName = 'UFBGA-64_5x5mm_Layout8x8_P0.5mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'VFBGA-100_7.0x7.0mm_Layout10x10_P0.65mm': Params(
+        #
+        # VFBGA-100, 10x10, 7x7mm package, pitch 0.65mm
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is VFBGA-100_7.0x7.0mm_Layout10x10_P0.65mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 7.0,      # body overall length
+        E = 7.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.325,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.65,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 10,      # number of pins along X axis (width)
+        npy = 10,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'VFBGA-100_7.0x7.0mm_Layout10x10_P0.65mm', # Old_modelName
+        modelName = 'VFBGA-100_7.0x7.0mm_Layout10x10_P0.65mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'VFBGA-49_5.0x5.0mm_Layout7x7_P0.65mm': Params(
+        #
+        # VFBGA-49, 7x7, 5x5mm package, pitch 0.65mm
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is VFBGA-49_5.0x5.0mm_Layout7x7_P0.65mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 5.0,      # body overall length
+        E = 5.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.325,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.65,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 7,      # number of pins along X axis (width)
+        npy = 7,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'VFBGA-49_5.0x5.0mm_Layout7x7_P0.65mm', # Old_modelName
+        modelName = 'VFBGA-49_5.0x5.0mm_Layout7x7_P0.65mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'XFBGA-121_8x8mm_Layout11x11_P0.65mm': Params(
+        #
+        # XFBGA-121, https://www.nxp.com/docs/en/package-information/SOT1533-1.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is XFBGA-121_8x8mm_Layout11x11_P0.65mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 8.0,      # body overall length
+        E = 8.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.325,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.65,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 11,      # number of pins along X axis (width)
+        npy = 11,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'XFBGA-121_8x8mm_Layout11x11_P0.65mm', # Old_modelName
+        modelName = 'XFBGA-121_8x8mm_Layout11x11_P0.65mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'XFBGA-36_3.5x3.5mm_Layout6x6_P0.5mm': Params(
+        #
+        # XFBGA-36, https://www.nxp.com/docs/en/package-information/SOT1555-1.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is XFBGA-36_3.5x3.5mm_Layout6x6_P0.5mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 3.5,      # body overall length
+        E = 3.5,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.25,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.5,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 6,      # number of pins along X axis (width)
+        npy = 6,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'XFBGA-36_3.5x3.5mm_Layout6x6_P0.5mm', # Old_modelName
+        modelName = 'XFBGA-36_3.5x3.5mm_Layout6x6_P0.5mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
+    'XFBGA-64_5.0x5.0mm_Layout8x8_P0.5mm': Params(
+        #
+        # XFBGA-64, https://www.nxp.com/docs/en/package-information/SOT1555-1.pdf
+        # This model have been auto generated based on the foot print file
+        # A number of paramters have been fixed or guessed, such as A and A1
+        # 
+        # The foot print that uses this 3D model is XFBGA-64_5.0x5.0mm_Layout8x8_P0.5mm.kicad_mod
+        # 
+        fp_z = 0.2,     # first pin indicator depth
+        fp_r = 0.4,          # First pin indicator radius
+        fp_d = 0.3,          # First pin indicator distance from edge
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 5.0,      # body overall length
+        E = 5.0,      # body overall width
+        A1 = 0.025,      # body-board separation
+        A = 0.75,       # body overall height
+        b = 0.25,      # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.5,       # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 8,      # number of pins along X axis (width)
+        npy = 8,      # number of pins along y axis (length)
+        excluded_pins = ("internals",), # pins to exclude -> None or "internals"
+        old_modelName = 'XFBGA-64_5.0x5.0mm_Layout8x8_P0.5mm', # Old_modelName
+        modelName = 'XFBGA-64_5.0x5.0mm_Layout8x8_P0.5mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_BGA.3dshapes',
+        ),
+
 }

--- a/cadquery/FCAD_script_generator/DIP_packages/FindMissingDIP3DModels.py
+++ b/cadquery/FCAD_script_generator/DIP_packages/FindMissingDIP3DModels.py
@@ -87,7 +87,9 @@ MakeAllfile = 'MakeFindMissingDIP3DModels.sh'
 FreeCadExe = '/c/users/stefan/Downloads/FreeCAD_0.17.11223_x64_dev_win/FreeCAD_0.17.11223_x64_dev_win/bin/FreeCAD.exe'
 MainGenerator = 'main_generator.py '
 
-
+#
+# This list will hold the missing 3D models
+#
 MissingModels = []
 
 #
@@ -341,6 +343,8 @@ def DoNotExcludeModel(subf):
 # Check if a 3D model given in the foot print file is misisng in the 3D model directory
 #
 def ModelDoNotExist(subf, currfile, NewA3Dmodel):
+
+    global SkippingModelCnt
     #
     # Shall the model be excluded becaouse it already exist
     #
@@ -379,6 +383,7 @@ def ModelDoNotExist(subf, currfile, NewA3Dmodel):
                         # 3D model already exist
                         #
 #                        print("3D model exist, skipping it    " + subf);
+                        SkippingModelCnt = SkippingModelCnt - 1
                         return False
 #                    print("3D model do not exist  " + NewA3Dmodel.model)
                 else:
@@ -420,6 +425,7 @@ def IsNotSpecialModel(NewA3Dmodel):
 #
 def FindMissingModels():
 
+    global SkippingModelCnt
     #
     print("Checking dir: " + FPDir)
     currdir = FPDir

--- a/cadquery/FCAD_script_generator/DIP_packages/FindMissingDIP3DModels.py
+++ b/cadquery/FCAD_script_generator/DIP_packages/FindMissingDIP3DModels.py
@@ -68,6 +68,8 @@ Defaultb =  0.46
 Defaultb1 =  1.52
 
 
+SkippingModelCnt = 0
+
 #
 # The path to foot print file directory in relation to where this script is placed
 #
@@ -83,7 +85,7 @@ MakeAllfile = 'MakeFindMissingDIP3DModels.sh'
 # The path to FreeCad, this path will be used in the MakeFindMissingDIP3DModels.sh script
 #
 FreeCadExe = '/c/users/stefan/Downloads/FreeCAD_0.17.11223_x64_dev_win/FreeCAD_0.17.11223_x64_dev_win/bin/FreeCAD.exe'
-MainGenerator = 'main_generator.py'
+MainGenerator = 'main_generator.py '
 
 
 MissingModels = []
@@ -107,6 +109,7 @@ SpecialModels =[
                 ['PowerIntegrations_SDIP-10C',              12.82,  7.62,  4.50, 2.54, 0.46, 10,  'tht', '[4]'], 
                 ['PowerIntegrations_SMD-8',                 10.24,  7.62,  4.90, 2.54, 0.46,  8,  'smd', '[0]'], 
                 ['PowerIntegrations_SMD-8B',                10.24,  7.62,  4.90, 2.54, 0.46,  8,  'smd', '[6]'], 
+                ['PowerIntegrations_SMD-8C',                10.24,  7.62,  4.90, 2.54, 0.46,  8,  'smd', '[3]'], 
                 ['PowerIntegrations_SMD-8C',                10.24,  7.62,  4.90, 2.54, 0.46,  8,  'smd', '[3]'], 
                 ['Toshiba_11-7A9',                           7.86,  7.86,  5.54, 2.54, 0.46,  6,  'tht', '[5]'], 
                 ['DIP-6_W8.89mm_SMDSocket_LongPads',         7.74,  8.89,  5.07, 2.54, 1.30,  6,  'tht', '[0]'], 
@@ -140,7 +143,7 @@ class A3Dmodel:
         self.SMDSocket = 'tht'
         self.PinDist = 0.0
         self.corner = 'fillet'
-        self.destdirprefix = ''
+        self.dest_dir_prefix = ''
         self.filename = ''
         self.rotation = 90
     
@@ -148,27 +151,27 @@ class A3Dmodel:
     # Print the module on stdout, for debuging purpose
     #
     def Print(self):
-        print("self.subf          " + self.subf)
-        print("self.currfile      " + self.currfile)
-        print("self.numpin        " + str(self.numpin))
-        print("self.model         " + self.model)
-        print("self.descr         " + self.descr)
-        print("self.D             " + str(self.D))
-        print("self.E             " + str(self.E))
-        print("self.E1            " + str(self.E1))
-        print("self.A             " + str(self.A))
-        print("self.A1            " + str(self.A1))
-        print("self.A2            " + str(self.A2))
-        print("self.npx           " + str(self.npx))
-        print("self.npy           " + str(self.npy))
-        print("self.e             " + str(self.e))
-        print("self.b             " + str(self.b))
-        print("self.m             " + str(self.m))
-        print("self.epad          " + str(self.epad))
-        print("self.SMDSocket     " + self.SMDSocket)
-        print("self.corner        " + self.corner)
-        print("self.excluded_pins " + self.excluded_pins)
-        print("self.destdirprefix " + self.destdirprefix)
+        print("self.subf            " + self.subf)
+        print("self.currfile        " + self.currfile)
+        print("self.numpin          " + str(self.numpin))
+        print("self.model           " + self.model)
+        print("self.descr           " + self.descr)
+        print("self.D               " + str(self.D))
+        print("self.E               " + str(self.E))
+        print("self.E1              " + str(self.E1))
+        print("self.A               " + str(self.A))
+        print("self.A1              " + str(self.A1))
+        print("self.A2              " + str(self.A2))
+        print("self.npx             " + str(self.npx))
+        print("self.npy             " + str(self.npy))
+        print("self.e               " + str(self.e))
+        print("self.b               " + str(self.b))
+        print("self.m               " + str(self.m))
+        print("self.epad            " + str(self.epad))
+        print("self.SMDSocket       " + self.SMDSocket)
+        print("self.corner          " + self.corner)
+        print("self.excluded_pins   " + self.excluded_pins)
+        print("self.dest_dir_prefix " + self.dest_dir_prefix)
     
         
     #
@@ -293,28 +296,28 @@ class A3Dmodel:
         datafile.write("        # \n")
         datafile.write("        # The foot print that uses this 3D model is " + self.subf + "\n")
         datafile.write("        # \n")
-
         datafile.write('        D  = ' + str(round(self.D, 2)) + ',         # body length\n')
         datafile.write('        E1 = ' + str(round(self.E1, 2)) + ',         # body width\n')
-        datafile.write('        E = ' + str(round(self.E, 2)) + ',          # body overall width\n')
+        datafile.write('        E  = ' + str(round(self.E, 2)) + ',         # body overall width\n')
         datafile.write('        A1 = ' + str(round(self.A1 , 2)) + ',          # body-board separation\n')
         datafile.write('        A2 = ' + str(round(self.A2 , 2)) + ',          # body height\n')
-        datafile.write('        b1 = ' + str(round(self.b1 , 2)) + ',          # pin width\n')
-        datafile.write('        b  = ' + str(round(self.b , 2)) + ',          # pin tip width\n')
-        datafile.write('        e = ' + str(round(self.e , 2)) + ',          # body-board separation\n')
-        datafile.write('        npins = ' + str(self.numpin) + ',          # number of pins\n')
+        datafile.write('        b1 = ' + str(round(self.b1 , 2)) + ',         # pin width\n')
+        datafile.write('        b  = ' + str(round(self.b , 2)) + ',         # pin tip width\n')
+        datafile.write('        e  = ' + str(round(self.e , 2)) + ',         # body-board separation\n')
+        datafile.write('        npins = ' + str(self.numpin) + ',         # number of pins\n')
         datafile.write("        modelName = '" + self.model + "',            # modelName\n")
         datafile.write('        rotation = ' + str(self.rotation) + ',      # rotation if required\n')
-        datafile.write("        type = '" + self.SMDSocket + "',          # tht, smd or thtsmd\n")
-        datafile.write("        corner = '" + self.corner + "',          # chamfer or fillet\n")
-        datafile.write('        excludepins = ' + self.excluded_pins + ',          # pin excluded\n')
+        datafile.write("        type = '" + self.SMDSocket + "',       # tht, smd or thtsmd\n")
+        datafile.write("        corner = '" + self.corner + "',   # chamfer or fillet\n")
+        datafile.write('        excludepins = ' + self.excluded_pins + ',  # pin excluded\n')
+        datafile.write("#        dest_dir_prefix = '../" + self.dest_dir_prefix + "',  # destination directory\n")
         
         datafile.write('        ),\n\n')
 
         #
         # Create the FreeCad command line
         #
-        commandfile.write(FreeCadExe + ' ' + MainGenerator + ' ' + self.model + '\n')
+        commandfile.write(FreeCadExe + ' ' + MainGenerator + self.model + '\n')
         
 #
 # Check if a foot print file should be excluded form being scanned
@@ -360,10 +363,12 @@ def ModelDoNotExist(subf, currfile, NewA3Dmodel):
                 line2 = line4.replace("\t", "/")
                 spline = line2.split('/')
                 if len(spline) > 2:
-                    NewA3Dmodel.destdirprefix = spline[1]
+                    NewA3Dmodel.dest_dir_prefix = spline[1]
                     NewA3Dmodel.filename = spline[2]
                     spline2 = spline[2].split('.wrl')
                     NewA3Dmodel.model = spline2[0]
+                    NewA3Dmodel.modelName = NewA3Dmodel.model
+                    NewA3Dmodel.old_modelName = NewA3Dmodel.model
                     #
                     line2 = spline[1] + '/' + spline[2]
                     Model3DFile = KISYS3DMOD + '/' + line2
@@ -454,29 +459,59 @@ def FindMissingModels():
                     #
                     if AddMissing:
                         print("Creating " + NewA3Dmodel.model);
+                        NewA3Dmodel.CleanUp()
                         MissingModels.append(NewA3Dmodel)
+                else:
+                    SkippingModelCnt = SkippingModelCnt + 1
 #                    NewA3Dmodel.Print()
 
 
 def SaveMissingModels():
 
-    datafile = open(ResultFile, "w") 
-    commandfile = open(MakeAllfile, "w") 
-    
-    commandfile.write('#!/bin/sh\n\n')
-    
-    for n in MissingModels:
-        n.PrintMissingModels(datafile, commandfile)
 
-    datafile.close()
-    commandfile.close()
+    if os.path.isfile(ResultFile):
+        os.remove(ResultFile)
+
+    if os.path.isfile(MakeAllfile):
+        os.remove(MakeAllfile)
+    
+    if len(MissingModels) > 0:
+        datafile = open(ResultFile, "w") 
+        commandfile = open(MakeAllfile, "w") 
         
+        commandfile.write('#!/bin/sh\n\n')
+        
+        for n in MissingModels:
+            n.PrintMissingModels(datafile, commandfile)
+
+        datafile.close()
+        commandfile.close()
+        
+        print(" ")
+    
 
 def main(argv):
+
+    global MissingModels
+    global SkippingModelCnt
+
+    SkippingModelCnt = 0
 
     MissingModels = []
     FindMissingModels()
     SaveMissingModels()
+    
+    if len(MissingModels) == 0 and SkippingModelCnt == 0:
+        print("No missing 3D models was found")
+        
+    if len(MissingModels) > 0:
+        print(str(len(MissingModels)) + " 3D models was missing")
+        print("Add paramters in " + ResultFile + " to file cq_parameters.py")
+        print("And execute batch file " + MakeAllfile)
+    
+    if SkippingModelCnt > 0:
+        print(str(SkippingModelCnt) + " Foot prints was skipped, add them to the ExcludeModels list or SpecialModels list")
+
         
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/cadquery/FCAD_script_generator/QFN_packages/FindMissingQFN3DModels.py
+++ b/cadquery/FCAD_script_generator/QFN_packages/FindMissingQFN3DModels.py
@@ -460,6 +460,8 @@ def DoNotExcludeModel(subf):
 # Check if a 3D model given in the foot print file is misisng in the 3D model directory
 #
 def ModelDoNotExist(subf, currfile, NewA3Dmodel):
+
+    global SkippingModelCnt
     #
     # Shall the model be excluded becaouse it already exist
     #
@@ -495,6 +497,7 @@ def ModelDoNotExist(subf, currfile, NewA3Dmodel):
                         # 3D model already exist
                         #
 #                        print("3D model exist, skipping it    " + subf);
+                        SkippingModelCnt = SkippingModelCnt - 1
                         return False
 #                    print("3D model do not exist  " + NewA3Dmodel.model)
                 else:
@@ -538,6 +541,7 @@ def IsNotSpecialModel(NewA3Dmodel):
 #
 def FindMissingModels():
 
+    global SkippingModelCnt
     #
     print("Checking dir: " + FPDir)
     currdir = FPDir


### PR DESCRIPTION
This push consist of 45 3D models for BGA foot prints.

The ordinary cq_parameters.py have been updated by a separate script and all 3D models can be recreated.

Several of the scripts have been updated so they give more extensive explination and all script look to their structure the same

3D model push
https://github.com/KiCad/kicad-packages3D/pull/454

3D model script push
https://github.com/easyw/kicad-3d-models-in-freecad/pull/221
