### PR TITLE
Add Artesyn ATA Series SMT DC to DC converter 3D model script.

### DIFF
--- a/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
@@ -977,4 +977,28 @@ all_params = {
         pin_color_key      = 'metal grey pins',  # Pin color
         dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
         ),
+
+    'Converter_DCDC_Artesyn_ATA-Series_SMD': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_Artesyn_ATA-Series_SMD',  # Model name
+        pintype   = 'smd',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 13.7,  # Package length
+        W  = 24.0,  # Package width
+        H  = 8.0,  # Package height
+        A1 = 0.25,  # Package board seperation
+        pin = ((-8.25, -8.89), (-8.25, -6.35), (-8.25, 6.35), (-8.25, 8.89), (8.25, 8.89), (8.25, 6.35), (8.25, -8.89)),  # Pin placement
+        pin1corner = (0.0, 0.0),  # Left upp corner relationsship to pin 1
+        pinpadh    = 0.2,  # Pin length, pad height
+        pinpadsize = 1.2,  # Pin diameter or pad size
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 1,  # If belly of caseing should be round (or flat)
+        rotation   = 0.0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        ),
 }


### PR DESCRIPTION
Please consider this addition to the DC to DC converter script to generate the 3D models for the SMT version of the [Artesyn ATA series](https://www.artesyn.com/power/assets/ata_series_ds_01apr2015_79c25814fd.pdf) DC to DC converter.