### PR TITLE
Added the 3D model for Seiko MS621F

### DIFF
--- a/cadquery/FCAD_script_generator/Battery/cq_Seiko_MSXXXX.py
+++ b/cadquery/FCAD_script_generator/Battery/cq_Seiko_MSXXXX.py
@@ -37,6 +37,7 @@ def make_case_Seiko_MS621F(params):
     #
     case1 = cq.Workplane("XY").workplane(offset=dh).moveTo(0.0, 0.0).circle(D / 2.0, False).extrude(H1)
     case1.edges("<Z").fillet((H1 / 3.0))
+    case1.edges(">Z").fillet(H1 / 20.0)
     case = case.union(case1)
     dh = dh + H1
     

--- a/cadquery/FCAD_script_generator/Battery/cq_Seiko_MSXXXX.py
+++ b/cadquery/FCAD_script_generator/Battery/cq_Seiko_MSXXXX.py
@@ -1,0 +1,123 @@
+
+import battery_common
+from battery_common import *
+
+
+def make_case_Seiko_MS621F(params):
+
+    A1 = params.A1              # Body PCB seperation
+    D  = params.D               # Battery diameter
+    H  = params.H               # Battery height
+    PL = params.PL              # Pad length
+    PW = params.PW              # Pad width
+    RW = params.RW              # Right width
+    MT = params.MT              # Metal thickness
+    rotation = params.rotation  # Rotation if required
+
+    D2 = D * 0.8
+    H2 = 0.075
+    D3 = D * 0.78
+    H3 = 0.23
+    #
+    H1 = H - ((2.0 * MT) + H2 + H3) 
+    D1 = D
+
+    dh = MT
+    #
+    # Create body
+    #
+    case = cq.Workplane("XY").workplane(offset=dh).moveTo(0.0, 0.0).circle(D3 / 2.0, False).extrude(H3)
+    case.edges("<Z").fillet(H3 / 2.2)
+    dh = dh + H3
+    #
+    case1 = cq.Workplane("XY").workplane(offset=dh).moveTo(0.0, 0.0).circle(D2 / 2.0, False).extrude(H2)
+    case1.edges("<Z").fillet(H2 / 2.2)
+    case = case.union(case1)
+    dh = dh + H2
+    #
+    case1 = cq.Workplane("XY").workplane(offset=dh).moveTo(0.0, 0.0).circle(D / 2.0, False).extrude(H1)
+    case1.edges("<Z").fillet((H1 / 3.0))
+    case = case.union(case1)
+    dh = dh + H1
+    
+    #
+    x = PW / 2.0
+    cx = (x - RW) - (D1 / 2.0)
+
+    case = case.translate((cx, 0.0, A1))
+    
+    if (rotation != 0):
+        case = case.rotate((0,0,0), (0,0,1), rotation)
+
+    return (case)
+
+
+def make_pins_Seiko_MS621F(params):
+
+    A1 = params.A1              # Body PCB seperation
+    D  = params.D               # Battery diameter
+    H  = params.H               # Battery height
+    PL = params.PL              # Pad length
+    PW = params.PW              # Pad width
+    RW = params.RW              # Right width
+    RW1 = params.RW1            # Right width 1
+    MT = params.MT              # Metal thickness
+    rotation = params.rotation  # Rotation if required
+
+    FreeCAD.Console.PrintMessage('\r\n make_pins_Seiko_MSXXXX \r\n')
+
+    TL = 0.5 # the width of the tounghs
+    D2 = D * 0.8
+    H2 = 0.075
+    D3 = D * 0.78
+    H3 = 0.23
+    #
+    H1 = H - ((2.0 * MT) + H2 + H3) 
+    D1 = D
+    #
+    x = PW / 2.0
+    cx = (x - RW) - (D1 / 2.0)
+
+    dh = MT
+    
+    #
+    pts = []
+    pts.append((0.0, 0.0 - PL))
+    pts.append((D3 * 0.9 + ((D1 - D3) / 2.0) + RW, 0.0 - PL))
+    pts.append((D3 * 0.9 + ((D1 - D3) / 2.0) + RW, 0.0 - (PL - TL)))
+    pts.append((D3 * 0.9 + ((D1 - D3) / 2.0), 0.0 - (PL - TL)))
+    pts.append(((D3 * 0.9 + ((D1 -D3) / 2.0)) - (PL - TL), 0.0))
+    pin = cq.Workplane("XY").workplane(offset=0.0).polyline(pts).close().extrude(MT)
+
+    x = 0.0 - (D3 * 0.9 + ((D1 - D3) / 2.0) + RW)
+    x = x + (PW / 2.0)
+    
+    pin = pin.translate((x, (PL / 2.0), A1))
+    
+    #
+    pts = []
+    pts.append((0.0, MT))
+    pts.append((0.0 - (RW1 - MT), MT))
+    pts.append((0.0 - (RW1 - MT), H))
+    pts.append((0.0 - (RW1 - MT) - (RW - RW1) - (D1 * 0.6), H))
+    pts.append((0.0 - (RW1 - MT) - (RW - RW1) - (D1 * 0.6), H - MT))
+    pts.append((0.0 - RW1, H - MT))
+    pts.append((0.0 - RW1, 0.0))
+    pin1 = cq.Workplane("XZ").workplane(offset=0.0).polyline(pts).close().extrude(PL)
+
+    case21 = cq.Workplane("XY").workplane(offset=0.0 - MT).moveTo(0.0 - (PW / 2.0), 0.0 - 1.5).rect(2.0 * PW, PL).extrude(2.0 * MT)
+    pin1 = pin1.cut(case21)
+
+    case21 = cq.Workplane("XY").workplane(offset=0.0).moveTo(0.0 - RW1 - (MT / 4.0), 0.0).rect(1.5 * MT, 0.0 - (2.0 * PL), centered=False).extrude(0.0 - PL)
+    case21 = case21.rotate((0,0,0), (1, 0, 0), 0.0 - 45.0)
+    case21 = case21.translate((0.0, 0.0 - TL, MT))
+    pin1 = pin1.cut(case21)
+
+    pin1 = pin1.translate((PW / 2.0, PL / 2.0, A1))
+    pin1.faces(">Z").edges(">X").fillet((MT / 2.0))
+    pin = pin.union(pin1)
+    
+    if (rotation != 0):
+        pin = pin.rotate((0,0,0), (0,0,1), rotation)
+
+    return (pin)

--- a/cadquery/FCAD_script_generator/Battery/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/Battery/cq_parameters.py
@@ -45,6 +45,12 @@ Params = namedtuple_with_defaults("Params", [
     'BM',                   # Center of body
 	'A1',				    # package board seperation
     'A2',                   # Belly distance to board
+    'D',                    # Diameter
+    'PW',                   # Pad width
+    'PL',                   # Pad length
+    'RW',                   # Right width
+    'RW1',                  # Right width 1
+    'MT',                   # Metal thickness
     'pins',                 # Pins tht/smd, x pos, y pos, 'round/rect', diameter/x size, y size, length
     'npthpins',             # npth holes
     'socket',               # 'type', centre diameter, length, height
@@ -582,6 +588,27 @@ all_params = {
         body_color_key  = 'black body',             # Body color
         pin_color_key   = 'metal grey pins',        # Pin color
         dest_dir_prefix = 'Battery.3dshapes'        # Destination directory
+        ),
+
+    'Seiko_MS621F': Params(
+        #
+        # http://www.belton.co.kr/inc/downfile.php?seq=58&file=pdf
+        # A number of parameters have been fixed or guessed, such as A2
+        # 
+        modelname = 'BatteryHolder_Seiko_MS621F',   # Model name
+        A1 = 0.0,                                   # Body PCB seperation
+        D = 6.8,                                    # Battery diameter
+        H = 2.7,                                    # Battery height
+        PW = 1.8,                                   # Pad width
+        PL = 2.0,                                   # Pad length
+        RW = 2.5,                                   # Right width
+        RW1 = 2.2,                                  # Right width 1
+        MT = 0.15,                                  # Metal thickness
+
+        rotation = 0,                               # Rotation if required
+        body_color_key = 'metal aluminum',          # Body color
+        pin_color_key = 'metal grey pins',          # Pin color
+        dest_dir_prefix = 'Battery.3dshapes',       # destination directory
         ),
 
 }

--- a/cadquery/FCAD_script_generator/Battery/main_generator.py
+++ b/cadquery/FCAD_script_generator/Battery/main_generator.py
@@ -158,6 +158,9 @@ from battery_casebutton import *
 import battery_casecylinder
 from battery_casecylinder import *
 
+import cq_Seiko_MSXXXX
+from cq_Seiko_MSXXXX import *
+
 
     
 def make_npthpins_S2(params):
@@ -264,8 +267,15 @@ def make_3D_model(models_dir, variant):
         #
     elif all_params[variant].modeltype == 'Cylinder1':
         case = make_case_Cylinder1(all_params[variant])
-        FreeCAD.Console.PrintMessage('make_pins\r\n')    
         pins = make_pins(all_params[variant])
+        show(case)
+        show(pins)
+        modelfileName = make_modelfileName_Common(all_params[variant])
+        #
+        #
+    elif variant == 'Seiko_MS621F':
+        case = make_case_Seiko_MS621F(all_params[variant])
+        pins = make_pins_Seiko_MS621F(all_params[variant])
         show(case)
         show(pins)
         modelfileName = make_modelfileName_Common(all_params[variant])
@@ -304,8 +314,6 @@ def make_3D_model(models_dir, variant):
             objs = GetListOfObjects(FreeCAD, doc)
     doc.Label = CheckedmodelName
 
-    FreeCAD.Console.PrintMessage("make_3D_model ..3.. \r\n")
-    
     del objs
     objs=GetListOfObjects(FreeCAD, doc)
     objs[0].Label = CheckedmodelName
@@ -313,7 +321,7 @@ def make_3D_model(models_dir, variant):
 
     script_dir=os.path.dirname(os.path.realpath(__file__))
     expVRML.say(models_dir)
-    out_dir=models_dir+ os.sep +  all_params[variant].dest_dir_prefix
+    out_dir=models_dir + os.sep +  all_params[variant].dest_dir_prefix
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
@@ -321,7 +329,7 @@ def make_3D_model(models_dir, variant):
     if LIST_license[0]=="":
         LIST_license=Lic.LIST_int_license
         LIST_license.append("")
-    Lic.addLicenseToStep(out_dir+'/', modelfileName + ".step", LIST_license,\
+    Lic.addLicenseToStep(out_dir + os.sep, modelfileName + ".step", LIST_license,\
                        STR_licAuthor, STR_licEmail, STR_licOrgSys, STR_licOrg, STR_licPreProc)
 
     # scale and export Vrml model


### PR DESCRIPTION
When created the 3D model for battery holder Seiko MS621F 
https://www.sii.co.jp/en/me/files/2014/02/file_EXTENDED_PRDCT_SPEC_75_FILE_11.jpg

It seems that the battery circles was off 0.4, earlier origo was at -4.6 but should be 5.0

Foot print push
https://github.com/KiCad/kicad-footprints/pull/1218

3D model push
https://github.com/KiCad/kicad-packages3D/pull/486

3D model script push
https://github.com/easyw/kicad-3d-models-in-freecad/pull/245


![bild](https://user-images.githubusercontent.com/25547797/50442639-0e88b100-0900-11e9-8c1a-ed803e1dbba8.png)

![bild](https://user-images.githubusercontent.com/25547797/50442647-147e9200-0900-11e9-8dfa-7ca576b6987c.png)

![bild](https://user-images.githubusercontent.com/25547797/50442950-860b1000-0901-11e9-8919-613d4d231e4a.png)

