### PR TITLE
Updated the DIP switches so the 3D model name match those in the new …

### DIFF
--- a/cadquery/FCAD_script_generator/DIP_parts/cq_base_model.py
+++ b/cadquery/FCAD_script_generator/DIP_parts/cq_base_model.py
@@ -488,7 +488,7 @@ class PartBase (object):
                                 (-self.pin_width / 4.0, 0.0),
                             ]).addMirror().make().extrude(self.pin_thickness)
 
-    def _make_angled_pin(self, pin_height=None, top_length=0.0, style='SMD'):
+    def _make_angled_pin(self, pin_height=None, top_length=0.0, top_extension=0.0, style='SMD'):
         """ create gull wing pin
 
         The pin will placed at coordinate 0, 0 and with the base at Z = 0
@@ -542,7 +542,16 @@ class PartBase (object):
                      .line(-self.pin_width, 0)\
                      .line(0, -top_length)\
                      .close().extrude(self.pin_thickness))
-
+        elif (round(top_extension, 6) != 0.0):
+            pin = pin.union(cq.Workplane("XZ")\
+                     .workplane(offset=-self.pin_thickness / 2)\
+                     .moveTo(self.pin_width / 2.0, 0.0)\
+                     .line(0.0, top_extension)\
+                     .line(-self.pin_width, 0.0)\
+                     .line(0.0, -top_extension)\
+                     .close().extrude(self.pin_thickness))
+        
+        
         return pin
 
     def _make_gullwing_pin(self, pin_height, bottom_length, r_upper_i=None, r_lower_i=None):

--- a/cadquery/FCAD_script_generator/DIP_parts/cq_model_piano_switch.py
+++ b/cadquery/FCAD_script_generator/DIP_parts/cq_model_piano_switch.py
@@ -47,21 +47,24 @@ class dip_switch_piano (PartBase):
 
     def __init__(self, params):
         PartBase.__init__(self, params)
-        self.make_me = params.type == CaseType.THT and params.num_pins >= 2 and params.num_pins <= 24 and params.pin_rows_distance == 7.62
+#        self.make_me = params.type == CaseType.THT and params.num_pins >= 2 and params.num_pins <= 24 and params.pin_rows_distance == 7.62
+        self.make_me = self.num_pins / 2 in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 #        if self.make_me:
         self.licAuthor = "Terje Io"
         self.licEmail = "https://github.com/terjeio"
         self.destination_dir = "Button_Switch_THT.3dshapes"
         self.footprints_dir = "Button_Switch_THT.pretty"
-        self.rotation = 90
+        self.rotation = 180
 
+        self.pin_rows_distance = 7.62
+        self.pin_pitch = 2.54
         self.pin_width = 0.6
         self.pin_thickness = 0.2
         self.pin_length = 3.2
 
         self.body_width = 10.8
         self.body_height = 10.2
-        self.body_length = self.num_pins * 1.27 + 3.9 / 2.0
+        self.body_length = ((self.num_pins * self.pin_pitch) / 2.0) + 1.56
         self.body_board_distance = 0
         self.body_board_pad_height = 0.5
 
@@ -74,11 +77,16 @@ class dip_switch_piano (PartBase):
         self.color_keys.append("white body")  # buttons
         self.color_keys.append("white body")  # pin mark
 
-        self.first_pin_pos = (self.pin_pitch * (self.num_pins / 4.0 - 0.5), self.pin_rows_distance / 2.0)
-        self.offsets =  ((self.first_pin_pos[1], -self.first_pin_pos[0], self.body_board_distance))
+        self.first_pin_pos = (self.pin_pitch * (self.num_pins / 4.0 - 0.5), self.pin_rows_distance)
+        self.offsets =  (((self.body_length / 2.0) - 1.40 - self.pin_width, self.pin_rows_distance / 2.0, self.body_board_distance))
+
 
     def makeModelName(self, genericName):
-        return 'SW_DIP_x' + '{:d}'.format(self.num_pins / 2) + '_W7.62mm_Piano'
+        if self.num_pins == 2 or self.num_pins == 12 or self.num_pins == 22:
+            return 'SW_DIP_SPSTx' + '{:02d}'.format(self.num_pins / 2) + '_Piano_10.8x' + '{:.1f}'.format(self.body_length) + 'mm_W7.62mm_P' + '{:.2f}'.format(self.pin_pitch) + 'mm'
+        else:
+            return 'SW_DIP_SPSTx' + '{:02d}'.format(self.num_pins / 2) + '_Piano_10.8x' + '{:.2f}'.format(self.body_length) + 'mm_W7.62mm_P' + '{:.2f}'.format(self.pin_pitch) + 'mm'
+
 
     def _make_switchpockets(self):
 
@@ -169,5 +177,44 @@ class dip_switch_piano (PartBase):
         show(self.make_pins())
         show(self.make_buttons())
         show(self.make_pinmark(self.button_width + 0.2))
+
+
+class dip_switch_piano_cts (dip_switch_piano):
+
+    def __init__(self, params):
+        dip_switch_piano.__init__(self, params)
+
+        self.make_me = self.num_pins / 2 in [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+
+        self.pin_width = 0.48
+        self.pin_length = 3.81
+
+        self.body_width = 9.78
+        self.body_height = 7.9
+        self.body_length = ((self.num_pins * self.pin_pitch) / 2.0) + 2.18
+
+        self.button_base = 0.1
+        self.button_heigth = 3.5
+
+        self.color_keys[0] = "black body"      # body
+        self.color_keys.append("white body")  # buttons
+        self.color_keys.append("white body")  # pin mark
+
+        self.first_pin_pos = (self.pin_pitch * (self.num_pins / 4.0 - 0.5), self.pin_rows_distance)
+        self.offsets =  (((self.body_length / 2.0) - 1.85 - self.pin_width, self.pin_rows_distance / 2.0, self.body_board_distance))
+
+
+    def make_body(self):
+
+        body = cq.Workplane(cq.Plane.XY())\
+                 .rect(self.body_length, self.body_width).extrude(self.body_height)\
+                 .faces(">Y").cut(self._make_switchpockets())
+
+        return body
+
+
+    def makeModelName(self, genericName):
+        return 'SW_DIP_SPSTx' + '{:02d}'.format(self.num_pins / 2) + '_Piano_CTS_Series194-' + '{:d}'.format(self.num_pins / 2) + 'MSTN_W7.62mm_P' + '{:.2f}'.format(self.pin_pitch) + 'mm'
+
 
 ### EOF ###

--- a/cadquery/FCAD_script_generator/DIP_parts/cq_model_pin_switch.py
+++ b/cadquery/FCAD_script_generator/DIP_parts/cq_model_pin_switch.py
@@ -47,13 +47,16 @@ class dip_switch (PartBase):
 
     def __init__(self, params):
         PartBase.__init__(self, params)
-        self.make_me = params.type == CaseType.THT and params.num_pins >=  2 and params.num_pins <= 24 and params.pin_rows_distance == 7.62
+        self.make_me = self.num_pins / 2 in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 #        if self.make_me:
         self.licAuthor = "Terje Io"
         self.licEmail = "https://github.com/terjeio"
         self.destination_dir = "Button_Switch_THT.3dshapes"
         self.footprints_dir = "Button_Switch_THT.pretty"
-        self.rotation = 90
+
+        self.rotation = 180
+        self.pin_rows_distance = 7.62
+        self.pin_pitch = 2.54
 
         self.pin_width = 0.6
         self.pin_thickness = 0.2
@@ -61,24 +64,29 @@ class dip_switch (PartBase):
 
         self.body_width = 9.9
         self.body_height = 5.85
-        self.body_length = self.num_pins * 1.27 + 3.9 / 2.0
+        self.body_length = ((self.num_pins * self.pin_pitch) / 2.0) + 2.18
         self.body_board_distance = 0.0
         self.body_board_pad_height = 0.5
 
         self.button_width = 1.4
         self.button_length = 1.6
-        self.button_base = 3.5
+        self.button_base = 3.62
         self.button_heigth = 1.2
 
-        self.color_keys[0] = "red body" #body
+        self.color_keys[0] = "blue body" #body
         self.color_keys.append("white body") #buttons
         self.color_keys.append("white body") #buttons
 
-        self.first_pin_pos = (self.pin_pitch * (self.num_pins / 4.0 - 0.5), self.pin_rows_distance / 2.0)
-        self.offsets =  ((self.first_pin_pos[1], -self.first_pin_pos[0], self.body_board_distance))
+        self.first_pin_pos = (self.pin_pitch * (self.num_pins / 4.0 - 0.5), (self.pin_rows_distance / 2.0) - self.pin_thickness)
+        self.offsets =  (((self.body_length / 2.0) - 1.8 - self.pin_width, self.pin_rows_distance / 2.0, self.body_board_distance))
+#        self.first_pin_pos = (self.pin_pitch * (self.num_pins / 4.0 - 0.5), self.pin_rows_distance / 2.0)
+#        self.offsets = ((self.first_pin_pos[1], -self.first_pin_pos[0], self.body_board_distance))
 
     def makeModelName(self, genericName):
-        return 'SW_DIP_x' + '{:d}'.format(self.num_pins / 2) + '_W7.62mm_Slide'
+        if self.num_pins == 6 or self.num_pins == 16:
+            return 'SW_DIP_SPSTx' + '{:02d}'.format(self.num_pins / 2) + '_Slide_9.78x' + '{:.1f}'.format(self.body_length) + 'mm_W7.62mm_P' + '{:.2f}'.format(self.pin_pitch) + 'mm'
+        else:
+            return 'SW_DIP_SPSTx' + '{:02d}'.format(self.num_pins / 2) + '_Slide_9.78x' + '{:.2f}'.format(self.body_length) + 'mm_W7.62mm_P' + '{:.2f}'.format(self.pin_pitch) + 'mm'
 
     def _make_switchpockets(self):
 
@@ -168,9 +176,60 @@ class dip_switch_low_profile (dip_switch):
     def __init__(self, params):
         dip_switch.__init__(self, params)
 
-        self.body_height = 3.0
+        self.make_me = self.num_pins / 2 in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        
+        self.rotation = 180
+        self.pin_rows_distance = 7.62
+        self.pin_pitch = 2.54
+
+        self.body_height = 3.8
+        self.body_width = 6.7
+        self.body_length = ((self.num_pins * self.pin_pitch) / 2.0) + 1.56
+
+        self.button_width = 0.7
+        self.button_length = 1.6
+        self.button_base = 3.62
+        self.button_heigth = 0.5
+
+        self.color_keys[0] = "black body" #body
+        self.color_keys.append("white body") #buttons
+        self.color_keys.append("white body") #buttons
+        
+#        self.first_pin_pos = (self.pin_pitch * (self.num_pins / 4.0 - 0.5), (self.pin_rows_distance / 2.0) - self.pin_thickness)
+#        self.offsets =  ((self.first_pin_pos[1], -self.first_pin_pos[0], self.body_board_distance))
+        self.first_pin_pos = (self.pin_pitch * (self.num_pins / 4.0 - 0.5), (self.pin_rows_distance / 2.0) - self.pin_thickness)
+        self.offsets =  (((self.body_length / 2.0) - 1.5 - self.pin_width, self.pin_rows_distance / 2.0, self.body_board_distance))
+
+    def make_body(self, pin_area_height=None, body_angle_top=12.0):
+        return self._make_plastic_body(pin_area_height, body_angle_top).cut(self._make_switchpockets())
+
+        body = cq.Workplane(cq.Plane.XY())\
+                 .rect(self.body_length, self.body_width).extrude(self.body_height)\
+                 .faces(">Z").cut(self._make_switchpockets())
+
+        body.faces("<Z").rect(self.body_length -1.0, self.body_width).cutBlind(self.body_board_pad_height)
+        body.faces("<Z").rect(self.body_length, self.body_width - 3.0).cutBlind(self.body_board_pad_height)
+
+        ##ok = Draft.makeShapeString("OK",'C:\windows\fonts\arial.ttf', 5)
+
+        return body
+
+    def make_pins(self):
+
+        l = self.pin_length + self.body_board_pad_height
+        pin = self._make_angled_pin(pin_height = l, top_extension=2.0, style='THT')
+        pin = pin.rotate((0,0,0), (1,0,0), 0.0 - 90.0)
+        pin = pin.translate((self.first_pin_pos[0], 0.0 - self.first_pin_pos[1], (self.body_height / 2.0) + self.body_board_distance))
+
+        pins = self._mirror(pin)
+
+        # create other side of the pins
+        return pins.union(pins.rotate((0,0,0), (0,0,1), 180))
 
     def makeModelName(self, genericName):
-        return 'SW_DIP_x' + '{:d}'.format(self.num_pins / 2) + '_W7.62mm_Slide_LowProfile'
+        if self.num_pins == 2 or self.num_pins == 12 or self.num_pins == 22:
+            return 'SW_DIP_SPSTx' + '{:02d}'.format(self.num_pins / 2) + '_Slide_6.7x' + '{:.1f}'.format(self.body_length) + 'mm_W7.62mm_P' + '{:.2f}'.format(self.pin_pitch) + 'mm_LowProfile'
+        else:
+            return 'SW_DIP_SPSTx' + '{:02d}'.format(self.num_pins / 2) + '_Slide_6.7x' + '{:.2f}'.format(self.body_length) + 'mm_W7.62mm_P' + '{:.2f}'.format(self.pin_pitch) + 'mm_LowProfile'
 
 ### EOF ###

--- a/cadquery/FCAD_script_generator/DIP_parts/main_generator.py
+++ b/cadquery/FCAD_script_generator/DIP_parts/main_generator.py
@@ -75,6 +75,7 @@ series = [
  cq_model_pin_switch.dip_switch,
  cq_model_pin_switch.dip_switch_low_profile,
  cq_model_piano_switch.dip_switch_piano,
+ cq_model_piano_switch.dip_switch_piano_cts,
  cq_model_smd_switch.dip_smd_switch,
  cq_model_smd_switch.dip_smd_switch_lowprofile,
  cq_model_smd_switch.dip_smd_switch_lowprofile_jpin,


### PR DESCRIPTION
The 3D model file name stated in the THT dip switch foot prints is no longer the same as before.

This push have modified the scripts that generate the 3D models so they now have the same file name as stated in the foot print.

3D model push
https://github.com/KiCad/kicad-packages3D/pull/489

3D model script push
https://github.com/easyw/kicad-3d-models-in-freecad/pull/248


Some screen shoots of the 3D models

![bild](https://user-images.githubusercontent.com/25547797/50494170-ee511300-0a21-11e9-9129-c457506fb196.png)

![bild](https://user-images.githubusercontent.com/25547797/50494173-f3ae5d80-0a21-11e9-9903-ccd68215a357.png)

![bild](https://user-images.githubusercontent.com/25547797/50494182-f90ba800-0a21-11e9-849c-db840356558f.png)

![bild](https://user-images.githubusercontent.com/25547797/50494188-0032b600-0a22-11e9-9801-a60d985bfeb5.png)
