### PR TITLE
fix CQGui import and window closing

### DIFF
--- a/cadquery/cq-ex2.FCMacro
+++ b/cadquery/cq-ex2.FCMacro
@@ -10,7 +10,7 @@ import FreeCAD, Draft, FreeCADGui
 import Idf
 import ImportGui
 
-from Gui.Command import *
+from CQGui.Command import *
 
 #Gui.SendMsgToActiveView("Run")
 Gui.activateWorkbench("CadQueryWorkbench")
@@ -18,12 +18,6 @@ import FreeCADGui as Gui
 
 import cadquery
 from Helpers import show
-
-#close the example
-App.setActiveDocument("Ex000_Introduction")
-App.ActiveDocument=App.getDocument("Ex000_Introduction")
-Gui.ActiveDocument=Gui.getDocument("Ex000_Introduction")
-App.closeDocument("Ex000_Introduction")
 
 #Getting the main window will allow us to start setting things up the way we want
 mw = FreeCADGui.getMainWindow()


### PR DESCRIPTION
adapt to CQGui introduced by [86c32c1](https://github.com/jmwright/cadquery-freecad-module/commits/86c32c1efb10fd8d744706c746fbad6426a822b8)
remove closing of `Ex000_Introduction`