### PR TITLE
remove duplicated function multiFuseObjs_wColors

### DIFF
--- a/cadquery/FCAD_script_generator/_tools/cq_cad_tools.py
+++ b/cadquery/FCAD_script_generator/_tools/cq_cad_tools.py
@@ -254,44 +254,6 @@ def multiFuseObjs_wColors(App, Gui, docName, objs, keepOriginals=False):
     return fused_obj
 
 ###################################################################
-# FuseObjs_wColors()  poeschlr
-#	Function to fuse multible objects together.
-###################################################################
-def multiFuseObjs_wColors(App, Gui, docName, objs, keepOriginals=False):
-
-    # Fuse two objects
-    App.ActiveDocument=None
-    Gui.ActiveDocument=None
-    App.setActiveDocument(docName)
-    App.ActiveDocument=App.getDocument(docName)
-    Gui.ActiveDocument=Gui.getDocument(docName)
-    App.activeDocument().addObject("Part::MultiFuse","Fusion")
-    App.activeDocument().Fusion.Shapes = objs
-    Gui.ActiveDocument.Fusion.ShapeColor=Gui.ActiveDocument.getObject(objs[0].Name).ShapeColor
-    Gui.ActiveDocument.Fusion.DisplayMode=Gui.ActiveDocument.getObject(objs[0].Name).DisplayMode
-    App.ActiveDocument.recompute()
-
-    App.ActiveDocument.addObject('Part::Feature','Fusion').Shape=App.ActiveDocument.Fusion.Shape
-    App.ActiveDocument.ActiveObject.Label=docName
-    fused_obj = App.ActiveDocument.ActiveObject
-
-    Gui.ActiveDocument.ActiveObject.ShapeColor=Gui.ActiveDocument.Fusion.ShapeColor
-    Gui.ActiveDocument.ActiveObject.LineColor=Gui.ActiveDocument.Fusion.LineColor
-    Gui.ActiveDocument.ActiveObject.PointColor=Gui.ActiveDocument.Fusion.PointColor
-    Gui.ActiveDocument.ActiveObject.DiffuseColor=Gui.ActiveDocument.Fusion.DiffuseColor
-    App.ActiveDocument.recompute()
-
-    # Remove the part1 part2 objects
-    if not keepOriginals:
-        for o in objs:
-            App.getDocument(docName).removeObject(o.Name)
-
-    # Remove the fusion itself
-    App.getDocument(docName).removeObject("Fusion")
-
-    return fused_obj
-
-###################################################################
 # FuseObjs_wColors_naming()  maui
 #	Function to fuse two objects together.
 ###################################################################


### PR DESCRIPTION
It looks like `multiFuseObjs_wColors` is duplicated at https://github.com/easyw/kicad-3d-models-in-freecad/blob/f2fe1731ecc88cb44da38f14bf6a1172e1a3d959/cadquery/FCAD_script_generator/_tools/cq_cad_tools.py#L260