### PR TITLE
Added Fujitsu-WLP-8 and modified the script to handle different dista…

### DIFF
--- a/cadquery/FCAD_script_generator/BGA_packages/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/BGA_packages/cq_parameters.py
@@ -46,7 +46,8 @@ Params =namedtuple_with_defaults ("Params", [
     'A2',   # body height or body bottom height optional, needed for molded
     'A',    # body  overall height
     'b',    # ball pin width diameter with a small extra to obtain a union of balls and case
-    'e',    # pin (center-to-center) distance
+    'e',    # pin (center-to-center) distance along x and y axis unless e1 is present
+    'ey',   # pin (center-to-center) distance along y-axis, if this parameter is not present, then e is used
     'sp',   # seating plane (pcb penetration)
     'npx',  # number of pins along X axis (width)
     'npy',  # number of pins along y axis (length)
@@ -70,6 +71,7 @@ kicad_naming_params_qfn = {
 #        A = 0.77,  # body height
 #        b = 0.505,  # ball pin width diameter with a small extra to obtain a union of balls and case
 #        e = 0.8,  # pin (center-to-center) distance
+#        ey = 0.4,  # pin (center-to-center) distance along y-axis, if this parameter is not present, then e is used
 #        sp = 0.0, #seating plane (pcb penetration)
 #        npx = 8,  # number of pins along X axis (width)
 #        npy = 6,  # number of pins along y axis (length)
@@ -79,6 +81,28 @@ kicad_naming_params_qfn = {
 #        rotation = -90, # rotation if required
 #        dest_dir_prefix = '',
 #        ),
+    'Fujitsu_WLP-15_2.28x3.092mm_Layout3x5_P0.4mm': Params( # from http://www.fujitsu.com/global/documents/products/devices/semiconductor/fram/lineup/MB85RS1MT-DS501-00022-7v0-E.pdf
+        fp_r = 0.3,     # first pin indicator radius
+        fp_d = 0.04,    # first pin indicator distance from edge
+        fp_z = 0.01,    # first pin indicator depth
+        ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 2.28,       # body overall length
+        E = 3.09,       # body overall width
+        A1 = 0.08,      # body-board separation
+        A = 0.25,       # body  overall height
+        b = 0.20,       # ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.4,        # pin (center-to-center) distance
+        ey = 0.3,        # pin (center-to-center) distance
+        sp = 0.0,       # seating plane (pcb penetration)
+        npx = 3,        # number of pins along X axis (width)
+        npy = 5,        # number of pins along y axis (length)
+        excluded_pins = (2, 4, 6, 8, 10, 12, 14), #pins to exclude -> None or "internals"
+        old_modelName = 'Fujitsu_WLP-15_2.28x3.092mm_Layout3x5_P0.4mm', #old_modelName
+        modelName = 'Fujitsu_WLP-15_2.28x3.092mm_Layout3x5_P0.4mm',
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '',
+        ),
+
     'BGA-9_3x3_1.6x1.6mm_Pitch0.5mm': Params( # from http://www.ti.com/lit/ds/symlink/bq27421-g1.pdf
         fp_r = 0.3,     # first pin indicator radius
         fp_d = 0.04,     # first pin indicator distance from edge

--- a/cadquery/FCAD_script_generator/BGA_packages/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/BGA_packages/cq_parameters.py
@@ -47,7 +47,7 @@ Params =namedtuple_with_defaults ("Params", [
     'A',    # body  overall height
     'b',    # ball pin width diameter with a small extra to obtain a union of balls and case
     'e',    # pin (center-to-center) distance along x and y axis unless e1 is present
-    'ey',   # pin (center-to-center) distance along y-axis, if this parameter is not present, then e is used
+    'ex',   # pin (center-to-center) distance along x-axis, if this parameter is not present, then e is used
     'sp',   # seating plane (pcb penetration)
     'npx',  # number of pins along X axis (width)
     'npy',  # number of pins along y axis (length)
@@ -71,7 +71,7 @@ kicad_naming_params_qfn = {
 #        A = 0.77,  # body height
 #        b = 0.505,  # ball pin width diameter with a small extra to obtain a union of balls and case
 #        e = 0.8,  # pin (center-to-center) distance
-#        ey = 0.4,  # pin (center-to-center) distance along y-axis, if this parameter is not present, then e is used
+#        ex = 0.4,  # pin (center-to-center) distance along x-axis, if this parameter is not present, then e is used
 #        sp = 0.0, #seating plane (pcb penetration)
 #        npx = 8,  # number of pins along X axis (width)
 #        npy = 6,  # number of pins along y axis (length)
@@ -86,16 +86,16 @@ kicad_naming_params_qfn = {
         fp_d = 0.04,    # first pin indicator distance from edge
         fp_z = 0.01,    # first pin indicator depth
         ef = 0.0,       # 0.05,      # fillet of edges  Note: bigger bytes model with fillet
-        D = 2.28,       # body overall length
-        E = 3.09,       # body overall width
+        D = 3.09,       # body overall length
+        E = 2.28,       # body overall width
         A1 = 0.08,      # body-board separation
         A = 0.25,       # body  overall height
         b = 0.20,       # ball pin width diameter with a small extra to obtain a union of balls and case
-        e = 0.4,        # pin (center-to-center) distance
-        ey = 0.3,        # pin (center-to-center) distance
+        e = 0.3,        # pin (center-to-center) distance
+        ex = 0.4,        # pin (center-to-center) distance
         sp = 0.0,       # seating plane (pcb penetration)
-        npx = 3,        # number of pins along X axis (width)
-        npy = 5,        # number of pins along y axis (length)
+        npx = 5,        # number of pins along X axis (width)
+        npy = 3,        # number of pins along y axis (length)
         excluded_pins = (2, 4, 6, 8, 10, 12, 14), #pins to exclude -> None or "internals"
         old_modelName = 'Fujitsu_WLP-15_2.28x3.092mm_Layout3x5_P0.4mm', #old_modelName
         modelName = 'Fujitsu_WLP-15_2.28x3.092mm_Layout3x5_P0.4mm',

--- a/cadquery/FCAD_script_generator/BGA_packages/main_generator.py
+++ b/cadquery/FCAD_script_generator/BGA_packages/main_generator.py
@@ -190,6 +190,7 @@ def make_case(params):
     molded = params.molded
     b   = params.b
     e   = params.e
+    ey   = params.ey
     sp   = params.sp
     npx = params.npx
     npy = params.npy
@@ -197,8 +198,10 @@ def make_case(params):
     rot = params.rotation
     dest_dir_pref = params.dest_dir_prefix
 
-    if cf is None:
-        cf = cff
+    if ey == None:
+        ey = e
+    if ey == 0:
+        ey = e
 
     if params.excluded_pins is not None:
         epl = list(params.excluded_pins)
@@ -230,11 +233,11 @@ def make_case(params):
             if "internals" in excluded_pins:
                 if str(int(pincounter)) not in excluded_pins:
                     if j==0 or j==npy-1 or i==0 or i==npx-1:
-                        pin = bpin.translate((first_pos_x-i*e, (npy*e/2-e/2)-j*e, 0)).\
+                        pin = bpin.translate((first_pos_x-i*e, (npy*ey/2-ey/2)-j*ey, 0)).\
                                 rotate((0,0,0), (0,0,1), 180)
                         pins.append(pin)
             elif str(int(pincounter)) not in excluded_pins:
-                pin = bpin.translate((first_pos_x-i*e, (npy*e/2-e/2)-j*e, 0)).\
+                pin = bpin.translate((first_pos_x-i*e, (npy*ey/2-ey/2)-j*ey, 0)).\
                         rotate((0,0,0), (0,0,1), 180)
                 pins.append(pin)
                 #expVRML.say(j)

--- a/cadquery/FCAD_script_generator/BGA_packages/main_generator.py
+++ b/cadquery/FCAD_script_generator/BGA_packages/main_generator.py
@@ -190,7 +190,7 @@ def make_case(params):
     molded = params.molded
     b   = params.b
     e   = params.e
-    ey   = params.ey
+    ex   = params.ex
     sp   = params.sp
     npx = params.npx
     npy = params.npy
@@ -198,10 +198,10 @@ def make_case(params):
     rot = params.rotation
     dest_dir_pref = params.dest_dir_prefix
 
-    if ey == None:
-        ey = e
-    if ey == 0:
-        ey = e
+    if ex == None:
+        ex = e
+    if ex == 0:
+        ex = e
 
     if params.excluded_pins is not None:
         epl = list(params.excluded_pins)
@@ -233,11 +233,11 @@ def make_case(params):
             if "internals" in excluded_pins:
                 if str(int(pincounter)) not in excluded_pins:
                     if j==0 or j==npy-1 or i==0 or i==npx-1:
-                        pin = bpin.translate((first_pos_x-i*e, (npy*ey/2-ey/2)-j*ey, 0)).\
+                        pin = bpin.translate((first_pos_x-i*e, (npy*ex/2-ex/2)-j*ex, 0)).\
                                 rotate((0,0,0), (0,0,1), 180)
                         pins.append(pin)
             elif str(int(pincounter)) not in excluded_pins:
-                pin = bpin.translate((first_pos_x-i*e, (npy*ey/2-ey/2)-j*ey, 0)).\
+                pin = bpin.translate((first_pos_x-i*e, (npy*ex/2-ex/2)-j*ex, 0)).\
                         rotate((0,0,0), (0,0,1), 180)
                 pins.append(pin)
                 #expVRML.say(j)


### PR DESCRIPTION
Added WLP- 08P-M01 from Fujitsu
http://www.fujitsu.com/global/documents/products/devices/semiconductor/fram/lineup/MB85RS1MT-DS501-00022-7v0-E.pdf

Note, this include a change in the main_generator.py
It is now possibly to add a parameter to have different step distances in x and y direction.

Please review this with extra care because the change affects core functionality.

In short, if parameter ey is present then the step in y direction is controlled by this parameter, otherwise e is used in both directions.


3D model push
https://github.com/KiCad/kicad-packages3D/pull/507

3D model script push
https://github.com/easyw/kicad-3d-models-in-freecad/pull/260


