### PR TITLE
Fix jst part numbers (remove leading 0)

### DIFF
--- a/cadquery/FCAD_script_generator/jst/cq_models/conn_jst_eh_params.py
+++ b/cadquery/FCAD_script_generator/jst/cq_models/conn_jst_eh_params.py
@@ -132,19 +132,19 @@ class series_params():
 
     variant_params = {
         'top_entry':{
-            'mpn_format_string': 'B{pincount:02}B-EH-A',
+            'mpn_format_string': 'B{pincount:d}B-EH-A',
             'orientation': 'V',
             'datasheet': 'http://www.jst-mfg.com/product/pdf/eng/eEH.pdf',
             'param_generator': make_params_straight,
-            'pinrange': range(2, 17),
+            'pinrange': range(2, 16),
             'mount_pin': ''
         },
         'side_entry':{
-            'mpn_format_string': 'S{pincount:02}B-EH',
+            'mpn_format_string': 'S{pincount:d}B-EH',
             'orientation': 'H',
             'datasheet': 'http://www.jst-mfg.com/product/pdf/eng/eEH.pdf',
             'param_generator': make_params_angled,
-            'pinrange': range(2, 17),
+            'pinrange': range(2, 16),
             'mount_pin': ''
         }
     }

--- a/cadquery/FCAD_script_generator/jst/cq_models/conn_jst_xh_params.py
+++ b/cadquery/FCAD_script_generator/jst/cq_models/conn_jst_xh_params.py
@@ -135,7 +135,7 @@ class series_params():
 
     variant_params = {
         'top_entry':{
-            'mpn_format_string': 'B{pincount:02}B-XH-A',
+            'mpn_format_string': 'B{pincount:d}B-XH-A',
             'orientation': 'V',
             'datasheet': 'http://www.jst-mfg.com/product/pdf/eng/eXH.pdf',
             'param_generator': make_params_straight,
@@ -151,7 +151,7 @@ class series_params():
         #     'mount_pin': ''
         # },
         'side_entry':{
-            'mpn_format_string': 'S{pincount:02}B-XH-A',
+            'mpn_format_string': 'S{pincount:d}B-XH-A',
             'orientation': 'H',
             'datasheet': 'http://www.jst-mfg.com/product/pdf/eng/eXH.pdf',
             'param_generator': make_params_angled,
@@ -159,7 +159,7 @@ class series_params():
             'mount_pin': ''
         },
         'side_entry_short':{
-            'mpn_format_string': 'S{pincount:02}B-XH-A-1',
+            'mpn_format_string': 'S{pincount:d}B-XH-A-1',
             'orientation': 'H',
             'datasheet': 'http://www.jst-mfg.com/product/pdf/eng/eXH.pdf',
             'param_generator': make_params_angled_short,


### PR DESCRIPTION
I screwed up it seems. JST does not use leading 0 in the part numbers of these parts.

Additionally: there is no 16 pin variant for the EH connectors.

Library pull request: https://github.com/KiCad/kicad-packages3D/pull/524