### PR TITLE
Changed sideopening for BatteryHolder_Keystone_1x2032 to be wider

### DIFF
--- a/cadquery/FCAD_script_generator/Battery/battery_casebutton.py
+++ b/cadquery/FCAD_script_generator/Battery/battery_casebutton.py
@@ -172,7 +172,7 @@ def make_case_Button2(params):
     #
     # Cut the jagged edge on the side
     #
-    ll = W / 4.0
+    ll = W / 3.3
     pts = []
     pts.append((ll, ll))
     pts.append((ll + (ll / 2.0), ll))


### PR DESCRIPTION
Chnaged Batteryholder_KeyStone_1x2032 on request in
https://github.com/KiCad/kicad-packages3D/pull/480

![bild](https://user-images.githubusercontent.com/25547797/53661073-c4a1ab80-3c5f-11e9-8cbd-20c55cc9f152.png)
