### PR TITLE
Added 3D model TDFN-6-1EP_2.5x2.5mm_P0.65mm_EP1.3x2mm

### DIFF
--- a/cadquery/FCAD_script_generator/QFN_packages/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/QFN_packages/cq_parameters.py
@@ -819,6 +819,32 @@ kicad_naming_params_qfn = {
         rotation = -90, # rotation if required
         dest_dir_prefix = '../Housings_DFN_QFN.3dshapes/'
         ),
+    'TDFN-6-1EP_2.5x2.5mm_P0.65mm_EP1.3x2mm': Params( # from https://www.nve.com/Downloads/ab3.pdf
+        c = 0.2,        # pin thickness, body center part height
+#        K=0.2,         # Fillet radius for pin edges
+        L = 0.3,        # pin top flat part length (including fillet radius)
+        fp_s = True,    # True for circular pinmark, False for square pinmark (useful for diodes)
+        fp_r = 0.4,     # first pin indicator radius
+        fp_d = 0.08,    # first pin indicator distance from edge
+        fp_z = 0.01,    # first pin indicator depth
+        ef = 0.0, # 0.05,   # fillet of edges  Note: bigger bytes model with fillet
+        cce = 0.1,      # 0.45 chamfer of the epad 1st pin corner
+        D = 2.5,        # body overall length
+        E = 2.5,        # body overall width
+        A1 = 0.05,      # body-board separation  maui to check
+        A2 = 0.8,       # body height
+        b = 0.3,        # pin width
+        e = 0.65,       # pin (center-to-center) distance
+        m = 0.00,       # margin between pins and body
+        ps = 'square',  # square pads
+        npx = 3,  # number of pins along X axis (width)
+        npy = 0,  # number of pins along y axis (length)
+        epad = (2.0, 1.3), # e Pad #epad = None, # e Pad
+        excluded_pins = None, #no pin excluded
+        modelName = 'TDFN-6-1EP_2.5x2.5mm_P0.65mm_EP1.3x2mm', #modelName
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '../Package_DFN_QFN.3dshapes/'
+        ),
     'DFN-6-1EP_3x3mm_Pitch0.95mm': Params( # from https://www.onsemi.com/pub/Collateral/506AX.PDF
         c = 0.2,        # pin thickness, body center part height
 #        K=0.2,          # Fillet radius for pin edges


### PR DESCRIPTION
Push of scripted variant of 
TDFN-6-1EP_2.5x2.5mm_P0.65mm_EP1.3x2mm

Instead of hand made model in push
https://github.com/KiCad/kicad-packages3D/pull/570

Data sheet 
https://www.nve.com/Downloads/ab3.pdf

3D model push
https://github.com/KiCad/kicad-packages3D/pull/573

3D model script push
https://github.com/easyw/kicad-3d-models-in-freecad/pull/290

Foot print push
https://github.com/KiCad/kicad-footprints/pull/1647

![bild](https://user-images.githubusercontent.com/25547797/59969195-a8948380-9548-11e9-9a31-7488077b6f64.png)

