### PR TITLE
Update murata naming to Murata

### DIFF
--- a/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
@@ -295,11 +295,11 @@ all_params = {
         ),
 
 
-    'Converter_DCDC_muRata_CRE1xxxxxx3C_THT': Params(   # ModelName
+    'Converter_DCDC_Murata_CRE1xxxxxx3C_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_muRata_CRE1xxxxxx3C_THT',  # Model name
+        modelName = 'Converter_DCDC_Murata_CRE1xxxxxx3C_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 6.1,  # Package length
         W  = 11.53,  # Package width
@@ -319,11 +319,11 @@ all_params = {
         ),
 
 
-    'Converter_DCDC_muRata_CRE1xxxxxxDC_THT': Params(   # ModelName
+    'Converter_DCDC_Murata_CRE1xxxxxxDC_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_muRata_CRE1xxxxxxDC_THT',  # Model name
+        modelName = 'Converter_DCDC_Murata_CRE1xxxxxxDC_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 9.9,  # Package length
         W  = 11.6,  # Package width
@@ -343,11 +343,11 @@ all_params = {
         ),
 
 
-    'Converter_DCDC_muRata_CRE1xxxxxxSC_THT': Params(   # ModelName
+    'Converter_DCDC_Murata_CRE1xxxxxxSC_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_muRata_CRE1xxxxxxSC_THT',  # Model name
+        modelName = 'Converter_DCDC_Murata_CRE1xxxxxxSC_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 6.1,  # Package length
         W  = 11.53,  # Package width
@@ -367,11 +367,11 @@ all_params = {
         ),
 
 
-    'Converter_DCDC_muRata_NMAxxxxDC_THT': Params(   # ModelName
+    'Converter_DCDC_Murata_NMAxxxxDC_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_muRata_NMAxxxxDC_THT',  # Model name
+        modelName = 'Converter_DCDC_Murata_NMAxxxxDC_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 9.8,  # Package length
         W  = 19.5,  # Package width
@@ -391,11 +391,11 @@ all_params = {
         ),
 
 
-    'Converter_DCDC_muRata_NMAxxxxSC_THT': Params(   # ModelName
+    'Converter_DCDC_Murata_NMAxxxxSC_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_muRata_NMAxxxxSC_THT',  # Model name
+        modelName = 'Converter_DCDC_Murata_NMAxxxxSC_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 6.0,  # Package length
         W  = 19.5,  # Package width
@@ -414,11 +414,11 @@ all_params = {
         ),
 
 
-    'Converter_DCDC_muRata_NXE2SxxxxMC_THT': Params(   # ModelName
+    'Converter_DCDC_Murata_NXE2SxxxxMC_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_muRata_NXE2SxxxxMC_THT',  # Model name
+        modelName = 'Converter_DCDC_Murata_NXE2SxxxxMC_THT',  # Model name
         pintype   = 'smd',  # Pin type, 'tht', 'smd'
         L  = 10.41,  # Package length
         W  = 12.7,  # Package width

--- a/cadquery/FCAD_script_generator/Crystal/cq_parameters_Resonator_SMD_muRata_CSTx.py
+++ b/cadquery/FCAD_script_generator/Crystal/cq_parameters_Resonator_SMD_muRata_CSTx.py
@@ -296,7 +296,7 @@ class cq_parameters_Resonator_SMD_muRata_CSTx():
 
     all_params = {
 
-        'muRata_CSTCC8M00G53': Params(
+        'Murata_CSTCC8M00G53': Params(
             #
             # http://www.farnell.com/datasheets/19296.pdf?_ga=1.247244932.122297557.1475167906
             # 
@@ -322,11 +322,11 @@ class cq_parameters_Resonator_SMD_muRata_CSTx():
             dest_dir_prefix = 'Crystal.3dshapes',   # destination directory
             ),
 
-        'muRata_CDSCB': Params(
+        'Murata_CDSCB': Params(
             #
             # http://cdn-reichelt.de/documents/datenblatt/B400/SFECV-107.pdf
             # 
-            filename = 'Resonator_SMD_muRata_CDSCB-2Pin_4.5x2.0mm',   # modelName
+            filename = 'Resonator_SMD_Murata_CDSCB-2Pin_4.5x2.0mm',   # modelName
             W = 4.5,                  # Body length
             E = 2.0,                  # Body width
             H = 0.4,                  # Body height
@@ -348,11 +348,11 @@ class cq_parameters_Resonator_SMD_muRata_CSTx():
             dest_dir_prefix = 'Crystal.3dshapes',   # destination directory
             ),
 
-        'muRata_CSTxExxV': Params(
+        'Murata_CSTxExxV': Params(
             #
             # https://www.murata.com/en-eu/products/productdata/8801162264606/SPEC-CSTNE16M0VH3C000R0.pdf
             # 
-            filename = 'Resonator_SMD_muRata_CSTxExxV-3Pin_3.0x1.1mm',   # modelName
+            filename = 'Resonator_SMD_Murata_CSTxExxV-3Pin_3.0x1.1mm',   # modelName
             W = 3.2,                  # Body length
             E = 1.3,                  # Body width
             H = 0.4,                  # Body height
@@ -374,11 +374,11 @@ class cq_parameters_Resonator_SMD_muRata_CSTx():
             dest_dir_prefix = 'Crystal.3dshapes',   # destination directory
             ),
 
-        'muRata_SFECV': Params(
+        'Murata_SFECV': Params(
             #
             # http://cdn-reichelt.de/documents/datenblatt/B400/SFECV-107.pdf
             # 
-            filename = 'Resonator_SMD_muRata_SFECV-3Pin_6.9x2.9mm',   # modelName
+            filename = 'Resonator_SMD_Murata_SFECV-3Pin_6.9x2.9mm',   # modelName
             W = 6.9,                  # Body length
             E = 2.9,                  # Body width
             H = 1.5,                  # Body height
@@ -400,11 +400,11 @@ class cq_parameters_Resonator_SMD_muRata_CSTx():
             dest_dir_prefix = 'Crystal.3dshapes',   # destination directory
             ),
 
-        'muRata_SFSKA': Params(
+        'Murata_SFSKA': Params(
             #
             # http://cdn-reichelt.de/documents/datenblatt/B400/SFECV-107.pdf
             # 
-            filename = 'Resonator_SMD_muRata_SFSKA-3Pin_7.9x3.8mm',   # modelName
+            filename = 'Resonator_SMD_Murata_SFSKA-3Pin_7.9x3.8mm',   # modelName
             W = 8.5,                  # Body length
             E = 3.8,                  # Body width
             H = 0.5,                  # Body height
@@ -426,11 +426,11 @@ class cq_parameters_Resonator_SMD_muRata_CSTx():
             dest_dir_prefix = 'Crystal.3dshapes',   # destination directory
             ),
 
-        'muRata_TPSKA': Params(
+        'Murata_TPSKA': Params(
             #
             # http://cdn-reichelt.de/documents/datenblatt/B400/SFECV-107.pdf
             # 
-            filename = 'Resonator_SMD_muRata_TPSKA-3Pin_7.9x3.8mm',   # modelName
+            filename = 'Resonator_SMD_Murata_TPSKA-3Pin_7.9x3.8mm',   # modelName
             W = 8.5,                  # Body length
             E = 3.8,                  # Body width
             H = 0.5,                  # Body height


### PR DESCRIPTION
Updating murata naming to "Murata" per https://github.com/KiCad/kicad-footprints/issues/545

kicad-footprints PR: https://github.com/KiCad/kicad-footprints/pull/1681
kicad-packages3D PR: https://github.com/KiCad/kicad-packages3D/pull/595

Currently covers:
    - Converter_DCDC
    - Crystals
        - Some crystals have not yet been generated
        and have still been updated.