### PR TITLE
Add support for custom pin shapes

### DIFF
--- a/cadquery/FCAD_script_generator/QFN_packages/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/QFN_packages/cq_parameters.py
@@ -33,15 +33,17 @@ Params = namedtuple("Params", [
     'b',    # pin width
     'e',    # pin (center-to-center) distance
     'm',    # margin between pins and body
-    'ps',   # pad shape square, rounded or concave
+    'ps',   # pad shape square, rounded, concave or custom
     'npx',  # number of pins along X axis (width)
     'npy',  # number of pins along y axis (length)
     'epad',  # exposed pad, None, radius as float for circular or the dimensions as tuple: (width, length) for square
     'excluded_pins', #pins to exclude
     'modelName', #modelName
     'rotation', #rotation if required
-    'dest_dir_prefix' #destination dir prefixD2 = params.epad[0]
+    'dest_dir_prefix', #destination dir prefixD2 = params.epad[0]
+    'pin_shapes',   # coords for pin shapes as [(x,y)]
 ])
+Params.__new__.__defaults__ = (None,) * len(Params._fields)
 
 all_params_qfn = {
     'AMS_LGA-10-1EP_2.7x4mm_P0.6mm': Params(


### PR DESCRIPTION
In case of complex pin shapes, it's now possible to add the `custom` pin shape and specify the differents pins shapes relatively to the center of the package.

Example for a `DFN-4` package: https://github.com/maximeborges/kicad-3d-models-in-freecad/commit/a68d78d343ed9624921e3f6543538770535e5409
![image](https://user-images.githubusercontent.com/159235/64866705-3c538880-d63c-11e9-8d7d-33b3857cb48a.png)
The 4 pins are defined using the `pin_shapes` optional field with the `ps` field set to `custom`.
The exposed pad is still defined using the `epad` field.