### PR TITLE
Update relay model naming to follow KLC

### DIFF
--- a/cadquery/FCAD_script_generator/Relay_THT/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/Relay_THT/cq_parameters.py
@@ -61,8 +61,8 @@ all_params = {
         #
         modelName = 'Relay_1P1T_NO_10x24x18.8mm_Panasonic_ADW11xxxxW_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
-        L  = 24,  # Package length
-        W  = 10,  # Package width
+        L  = -10,  # Package length
+        W  = 24,  # Package width
         H  = 18.8,  # Package height
         A1 = 0.1,   # Package board seperation
 		#rim_h = 0.7 # TODO: Improve the model by adding the correct rim
@@ -73,10 +73,10 @@ all_params = {
 		#    (15, -8.75, 2, 0.5)),
         pin = (
 		    (0.0, 0.0, 'round', 0.4),
-			(0.0, -7.5, 'round', 0.4),
-			(21, 0.0, 'rect', 0.8, 0.2),
-			(17.5, -7.5, 'rect', 0.8, 0.2)),  # Pin placement
-        pin1corner = (-1.5, -8.75),  # Left up corner relationsship to pin 1
+			(7.5, 0.0, 'round', 0.4),
+			(0.0, 21, 'rect', 0.8, 0.2),
+			(7.5, 17.5, 'rect', 0.8, 0.2)),  # Pin placement
+        pin1corner = (8.75, -1.5),  # Left up corner relationsship to pin 1
         pinpadh    = 3.5,           # Pin length, pad height
         pinpadsize = 1.0,           # Pin diameter or pad size
         show_top   = 0,             # If top should be visible or not

--- a/cadquery/FCAD_script_generator/Relay_THT/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/Relay_THT/cq_parameters.py
@@ -55,11 +55,11 @@ Params = namedtuple_with_defaults("Params", [
 
 all_params = {
 
-    'Relay_1P1T_Panasonic_ADW11_FormA': Params(   # ModelName
+    'Relay_1P1T_NO_10x24x18.8mm_Panasonic_ADW11xxxxW_THT': Params(   # ModelName
         #
         # https://www.panasonic-electric-works.com/pew/es/downloads/ds_dw_hl_en.pdf
         #
-        modelName = 'Relay_1P1T_Panasonic_ADW11_FormA',  # Model name
+        modelName = 'Relay_1P1T_NO_10x24x18.8mm_Panasonic_ADW11xxxxW_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
         L  = 24,  # Package length
         W  = 10,  # Package width


### PR DESCRIPTION
Follow up of https://github.com/easyw/kicad-3d-models-in-freecad/pull/289

Naming convention in https://github.com/KiCad/kicad-footprints/pull/1638