### PR TITLE
error when importing in linux otherwise

### DIFF
--- a/cadquery/FCAD_script_generator/DIP_parts/main_generator.py
+++ b/cadquery/FCAD_script_generator/DIP_parts/main_generator.py
@@ -48,7 +48,7 @@ script_dir  = os.path.dirname(os.path.realpath(__file__))
 scripts_root = script_dir.split(script_dir.split(os.sep)[-1])[0]
 
 sys.path.append(script_dir)
-sys.path.append(scripts_root + "\_tools")
+sys.path.append(scripts_root + "/_tools")
 
 from cq_model_generator import All, ModelGenerator
 


### PR DESCRIPTION
slash not working in linux:

```
import exportPartToVRML as expVRML
No module named 'exportPartToVRML'
```