### PR TITLE
Py2 to Py3 for connectors pin headers

### DIFF
--- a/cadquery/FCAD_script_generator/Connector_PinHeader/launch-cq-Connector_PinHeader
+++ b/cadquery/FCAD_script_generator/Connector_PinHeader/launch-cq-Connector_PinHeader
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Absolute path to this script. /home/user/bin/foo.sh
+SCRIPT=$(readlink -f $0)
+# Absolute path this script is in. /home/user/bin
+SCRIPTPATH=`dirname $SCRIPT`
+echo $SCRIPTPATH
+cd $SCRIPTPATH
+#FreeCAD  main_generator.py
+FreeCAD main_generator.py PinHeader_1xyy_P2.54mm_Vertical 10,17
+

--- a/cadquery/FCAD_script_generator/Connector_PinHeader/launch-cq-Connector_PinHeader.sh
+++ b/cadquery/FCAD_script_generator/Connector_PinHeader/launch-cq-Connector_PinHeader.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Absolute path to this script. /home/user/bin/foo.sh
+SCRIPT=$(readlink -f $0)
+# Absolute path this script is in. /home/user/bin
+SCRIPTPATH=`dirname $SCRIPT`
+echo $SCRIPTPATH
+cd $SCRIPTPATH
+#FreeCAD  main_generator.py
+FreeCAD main_generator.py PinHeader_1xyy_P2.54mm_Vertical 10,17
+


### PR DESCRIPTION
I wanted to check why my connectors are all "white".
So, I took this generator and found it not python3 friendly.
Now it is, eg generates the pin headers and they are colored.

Maybe you can save me lot of searches on why I don't have colors on my connectors...

(this is after destroying all the previous repo and mess of PR+commit, now
master only, no more branches shitty things)