### PR TITLE
Fusion of ACDC & DCDC generators

### DIFF
--- a/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
@@ -61,6 +61,7 @@ Params = namedtuple_with_defaults("Params", [
 ])
 
 p = 2.54                # no typo error
+pm= 2
 all_params = {
 
 
@@ -997,7 +998,7 @@ all_params = {
                ('rect', 3*p, 0.0, 0.5, 0.25, 3.2),
                ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
                ('rect', 5*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
-        pin1corner = (-2.3, -2.5-0.25/2),  # Left upp corner relationsship to pin 1
+        pin1corner = (-2.15, -2.5+0.25/2),  # Left upp corner relationsship to pin 1
         show_top   = False,  # If top should be visible or not
         corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
         roundbelly = 0,  # If belly of caseing should be round (or flat)
@@ -1037,17 +1038,23 @@ all_params = {
 
     'Converter_DCDC_TRACO_TMR-xxxx_THT': Params(   # ModelName
         #
-        #
+        #  footprint silk with Y error size
         #
         modelName = 'Converter_DCDC_TRACO_TMR-xxxx_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
-        L  = 21.8,  # Package length
-        W  = 9.2,   # Package width
-        H  = 11.0,  # Package height
-        A1 = 0.1,   # Package board separation
-        rim = None, # No rim
-        pin = (('round', 0.0, 0.0, 0.5, 4.0), ('round', 2.54, 0.0, 0.5, 4.0), ('round', 5.08, 0.0, 0.5, 4.0), ('round', 10.16, 0.0, 0.5, 4.0), ('round', 12.7, 0.0, 0.5, 4.0), ('round', 15.24, 0.0, 0.5, 4.0), ('round', 17.78, 0.0, 0.5, 4.0)),  # Pin placement
-        pin1corner = (-2.0, -3.2),  # Left upp corner relationsship to pin 1
+        L  = 21.8,   # Package length
+        W  = 9.2,    # Package width
+        H  = 11.1,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.2/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 4.0)),  # Pin placement
+        pin1corner = (-2.0, -3.2-0.25/2),  # Left upp corner relationsship to pin 1
         show_top   = False,  # If top should be visible or not
         corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
         roundbelly = 0,  # If belly of caseing should be round (or flat)
@@ -1901,7 +1908,7 @@ all_params = {
         W  = 9.25,   # Package width
         H  = 12.45,  # Package height
         A1 = 0.1,    # Package board separation
-        rim = (1, 3, 0.5),
+        rim = (0.5, 9.25/2 -0.001, 0.5),
         pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
                ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
                ('rect', 2*p, 0.0, 0.5, 0.25, 3.2),
@@ -1909,7 +1916,7 @@ all_params = {
                ('rect', 6*p, 0.0, 0.5, 0.25, 3.2),
                ('rect', 7*p, 0.0, 0.5, 0.25, 3.2),
                ('rect', 8*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
-        pin1corner = (-2.0, -3.0 -0.25/2),  # Left upp corner relationsship to pin 1
+        pin1corner = (-2.0, -3.0+0.25/2),  # Left upp corner relationsship to pin 1
         show_top   = False,  # If top should be visible or not
         corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
         roundbelly = 0,  # If belly of caseing should be round (or flat)
@@ -2275,12 +2282,11 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TMAHxxxxx_THT': Params(   # ModelName
-    'test':Params(   # ModelName
+    'Converter_DCDC_TRACO_TMHxxxxx_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TMAHxxxxx_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TMHxxxxx_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 19.5,   # Package length
         W  = 7.50,   # Package width
@@ -2293,6 +2299,1109 @@ all_params = {
                ('rect', 4*p, 0.0, 0.5, 0.25, 3.0),
                ('rect', 5*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
         pin1corner = (-2.30, -1.25-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMR2-xxxxE_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMR2-xxxxE_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 21.8,   # Package length
+        W  = 9.3,    # Package width
+        H  = 11.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.3/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.0, -2.7+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMR2-xxxxWIN_THT': Params(   # ModelName
+        #
+        # equivalent to TMR2-xxxxWI
+        #
+        modelName = 'Converter_DCDC_TRACO_TMR2-xxxxWIN_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 21.8,   # Package length
+        W  = 9.3,    # Package width
+        H  = 11.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.3/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.0, -2.7+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMR3-xxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMR3-xxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 21.8,   # Package length
+        W  = 9.2,    # Package width
+        H  = 11.1,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.2/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 4.0)),  # Pin placement
+        pin1corner = (-2.0, -3.2-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMR3-xxxxE_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMR3-xxxxE_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 21.8,   # Package length
+        W  = 9.3,    # Package width
+        H  = 11.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.3/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.0, -2.7+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMR3-xxxxHI_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMR3-xxxxHI_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 21.8,   # Package length
+        W  = 9.2,    # Package width
+        H  = 11.1,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.2/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 4.0)),  # Pin placement
+        pin1corner = (-2.0, -3.2-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMR3-xxxxWI_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMR3-xxxxWI_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 21.8,   # Package length
+        W  = 9.2,    # Package width
+        H  = 11.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.2/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 4.0),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 4.0)),  # Pin placement
+        pin1corner = (-2.0, -3.2-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_DCDC_TRACO_TMR3-xxxxWIE_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMR3-xxxxWIE_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 21.8,   # Package length
+        W  = 9.3,    # Package width
+        H  = 11.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.3/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.0, -2.7+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMR6-xxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMR6-xxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 21.8,   # Package length
+        W  = 9.1,    # Package width
+        H  = 11.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (-2.0, -3.2-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMR6-xxxxWI_THT': Params(   # ModelName
+        #
+        # = TMR6
+        #
+        modelName = 'Converter_DCDC_TRACO_TMR6-xxxxWI_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 21.8,   # Package length
+        W  = 9.1,    # Package width
+        H  = 11.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (-2.0, -3.2-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMV-xxxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMV-xxxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 6.1,    # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 6.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.3, +4.75 -6.1 -0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMV-xx24_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMV-24xxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 7.1,    # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.3, +4.75 -7.1 -0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_DCDC_TRACO_TMV2-xxxxHI_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMV2-xxxxHI_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 7.1,    # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.3, -1.55 -0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_DCDC_TRACO_TMV-xxxxxEN_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMV-xxxxxEN_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 22.0,   # Package length
+        W  = 7.5,    # Package width
+        H  = 12.5,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.5/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-3.5, -2 +0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_DCDC_TRACO_TMV-xxxxxHI_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMV-xxxxxHI_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 7.1,    # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.3, -1.55-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TRV1-xxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TRV1-xxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 6.1,    # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 6.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.35, -1.3+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TRV1-24xx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TRV1-24xx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 7.1,    # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.35, -1.3+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TRV1-xxxxM_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TRV1-xxxxM_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.6,   # Package length
+        W  = 9.9,    # Package width
+        H  = 12.5,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.9/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*pm, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 6*pm, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 7*pm, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 8*pm, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (16.0+1.8-19.6, -2.3),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TEC2-xxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TEC2-xxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 21.8,   # Package length
+        W  = 9.1,    # Package width
+        H  = 11.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (7*p+2-21.8, -3.2-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TEC2-xxxxWI_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TEC2-xxxxWI_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 21.8,   # Package length
+        W  = 9.1,    # Package width
+        H  = 11.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (7*p+2-21.8, -3.2-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TEC3-xxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TEC3-xxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 21.8,   # Package length
+        W  = 9.1,    # Package width
+        H  = 11.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (7*p+2-21.8, -3.2-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TEC3-xxxxWI_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TEC3-xxxxWI_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 21.8,   # Package length
+        W  = 9.1,    # Package width
+        H  = 11.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (7*p+2-21.8, -3.2-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TRA1-xxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TRA1-xxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 6.1,    # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 6.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.3, -1.3+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TRA1-24xx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TRA1-24xx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 7.1,    # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.3, -1.3+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TRA3-xxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TRA3-xxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 7.6,    # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.6/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.55, -1.3+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TRN1-xxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TRN1-xxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 11.9,   # Package length
+        W  = 7.7,    # Package width
+        H  = 11.0,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.7/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*pm, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*pm+0.8, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 3*pm+0.8, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 4*pm+0.8, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (8.8+1.6-11.9,3.7-7.7),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TRN3-xxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TRN3-xxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 11.9,   # Package length
+        W  = 7.7,    # Package width
+        H  = 11.0,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.7/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*pm, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*pm+0.8, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 3*pm+0.8, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 4*pm+0.8, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (8.8+1.6-11.9,3.7-7.7),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_DCDC_TRACO_TSN1-xxxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TSN1-xxxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 11.7,   # Package length
+        W  = 7.5,    # Package width
+        H  = 16.5,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.5/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.3, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.3, 4.1),
+               ('rect', 2*p, 0.0, 0.5, 0.3, 4.1)),  # Pin placement
+        pin1corner = (-3.3, -7.5+3.1),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_DCDC_TRACO_TSR05-xxxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TSR05-xxxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 11.5,   # Package length
+        W  = 7.55,   # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.55/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.7, 0.25, 4.1),
+               ('rect', 1*p, 0.0, 0.7, 0.25, 4.1),
+               ('rect', 2*p, 0.0, 0.7, 0.25, 4.1)),  # Pin placement
+        pin1corner = (-3.3, -7.55+2.0+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TSR06-xxxxxWI_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TSR06-xxxxxWI_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 12.0,   # Package length
+        W  = 8.6,    # Package width
+        H  = 13.4,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 8.6/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (2*p+3.5-12.0, -7.55+2.0+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TSR1-xxxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TSR1-xxxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 11.7,   # Package length
+        W  = 7.5,    # Package width
+        H  = 10.1,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.5/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (2*p+3.3-11.7, -5.5),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_DCDC_TRACO_TSR1-xxxxE_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TSR1-xxxxE_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 11.6,   # Package length
+        W  = 7.5,    # Package width
+        H  = 10.1,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.5/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.3, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.3, 4.1),
+               ('rect', 2*p, 0.0, 0.5, 0.3, 4.1)),  # Pin placement
+        pin1corner = (-3.26, -5.45),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TSR2-xxxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TSR2-xxxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 14.0,   # Package length
+        W  = 7.5,    # Package width
+        H  = 10.1,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.5/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.46, 0.46, 4.1),
+               ('rect', 1*p, 0.0, 0.46, 0.46, 4.1),
+               ('rect', 2*p, 0.0, 0.46, 0.46, 4.1)),  # Pin placement
+        pin1corner = (2*p+4.5-14.0, 3.89-7.5),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_DCDC_TRACO_TSRN1-xxxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TSRN1-xxxxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 11.7,   # Package length
+        W  = 7.5,    # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.5/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (-3.3, 2.4-7.5),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TEA1-0505_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TEA1-0505_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 11.68,  # Package length
+        W  = 6.0,    # Package width
+        H  = 9.65,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 6.0/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (-2.03, 0.9-6.0),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_DCDC_TRACO_TEA1-0505E_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TEA1-0505E_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 6.0,    # Package width
+        H  = 9.5,    # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 6.0/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (-2.40, -0.9),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TEA1-0505HI_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TEA1-0505HI_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 6.0,    # Package width
+        H  = 9.5,    # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 6.0/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (-2.40, -0.9),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_DCDC_TRACO_TEC2-xxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TEC2-xxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 21.8,   # Package length
+        W  = 9.1,    # Package width
+        H  = 11.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (7*p+2-21.8, -3.2-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TEC2-xxxxWI_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TEC2-xxxxWI_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 21.8,   # Package length
+        W  = 9.1,    # Package width
+        H  = 11.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (7*p+2-21.8, -3.2-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TEC3-xxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TEC3-xxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 21.8,   # Package length
+        W  = 9.1,    # Package width
+        H  = 11.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (7*p+2-21.8, -3.2-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TEC3-xxxxWI_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TEC3-xxxxWI_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 21.8,   # Package length
+        W  = 9.1,    # Package width
+        H  = 11.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (7*p+2-21.8, -3.2-0.25/2),  # Left upp corner relationsship to pin 1
         show_top   = False,  # If top should be visible or not
         corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
         roundbelly = 0,  # If belly of caseing should be round (or flat)

--- a/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
@@ -982,11 +982,11 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TMR-1-xxxx_Single_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TMR1-xx1x_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TMR-1-xxxx_Single_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TMR1-xx1x_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 17.0,  # Package length
         W  = 7.62,  # Package width
@@ -996,7 +996,6 @@ all_params = {
         pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
                ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
                ('rect', 3*p, 0.0, 0.5, 0.25, 3.2),
-               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
                ('rect', 5*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
         pin1corner = (-2.15, -2.5+0.25/2),  # Left upp corner relationsship to pin 1
         show_top   = False,  # If top should be visible or not
@@ -1009,11 +1008,11 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TMR-1-xxxx_Dual_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TMR1-xx2x_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TMR-1-xxxx_Dual_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TMR1-xx2x_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 17.0,  # Package length
         W  = 7.62,  # Package width
@@ -1036,7 +1035,7 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TMR-xxxx_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TMR-xxxx_THT': Params(   # ModelName   TRACO TMR 2
         #
         #  footprint silk with Y error size
         #
@@ -2010,11 +2009,37 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TBA1-xxxxE_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TBA1-xx1xE_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TBA1-xxxxE_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TBA1-xx1xE_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.50,  # Package length
+        W  = 6.0,    # Package width
+        H  = 9.5+0.5,# Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 2.999, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.40, -1.35),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TBA1-xx2xE_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TBA1-xx2xE_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 19.50,  # Package length
         W  = 6.0,    # Package width
@@ -2037,11 +2062,37 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TBA1-xxxxHI_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TBA1-xx1xHI_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TBA1-xxxxHI_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TBA1-xxxxHI_Single_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.50,  # Package length
+        W  = 6.0,    # Package width
+        H  = 9.5+0.5,# Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 2.999, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.40, -1.35),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TBA1-xx2xHI_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TBA1-xx2xHI_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 19.50,  # Package length
         W  = 6.0,    # Package width
@@ -2064,11 +2115,39 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TBA2-xxxx_THT': Params(   # ModelName
+
+    'Converter_DCDC_TRACO_TBA2-xx1x_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TBA2-xxxx_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TBA2-xx1x_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.55,  # Package length
+        W  = 7.6,    # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.45, 3.78, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.40, -1.35),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_DCDC_TRACO_TBA2-xx2x_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TBA2-xx2x_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 19.55,  # Package length
         W  = 7.6,    # Package width
@@ -2091,11 +2170,37 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TMA05xxx_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TMA05xxS_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TMA05xxx_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TMA05xxS_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 6.10,   # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 3.049, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.10, -1.3+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMA05xxD_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMA05xxD_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 19.5,   # Package length
         W  = 6.10,   # Package width
@@ -2118,11 +2223,37 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TMA12xxx_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TMA12xSx_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TMA12xxx_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TMA12xSx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 6.10,   # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 3.049, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.10, -1.3+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMA12xDx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMA12xDx_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 19.5,   # Package length
         W  = 6.10,   # Package width
@@ -2145,11 +2276,37 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TMA15xxx_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TMA15xxS_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TMA15xxx_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TMA15xxS_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 7.10,   # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 3.549, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.10, -1.3+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMA15xxD_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMA15xxD_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 19.5,   # Package length
         W  = 7.10,   # Package width
@@ -2172,11 +2329,38 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TMA24xxx_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TMA24xxS_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TMA24xxx_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TMA24xxS_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 7.10,   # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 3.549, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.10, -1.3+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_DCDC_TRACO_TMA24xxD_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMA24xxD_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 19.5,   # Package length
         W  = 7.10,   # Package width
@@ -2199,11 +2383,37 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TMAPxxxxx_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TMAPxxxxS_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TMAPxxxxx_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TMAPxxxxS_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 7.10,   # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 3.549, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.10, -1.8-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMAPxxxxD_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMAPxxxxD_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 19.5,   # Package length
         W  = 7.10,   # Package width
@@ -2282,11 +2492,37 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TMHxxxxx_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TMHxxxxS_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TMHxxxxx_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TMHxxxxS_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 7.50,   # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 3.749, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.30, -1.25-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMHxxxxD_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMHxxxxD_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 19.5,   # Package length
         W  = 7.50,   # Package width
@@ -2570,11 +2806,37 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TMV-xxxxx_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TMV-xxxxS_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TMV-xxxxx_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TMV-xxxxS_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 6.1,    # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 6.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.3, +4.75 -6.1 -0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMV-xxxxD_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMV-xxxxD_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 19.5,   # Package length
         W  = 6.1,    # Package width
@@ -2597,11 +2859,37 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TMV-xx24_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TMV-24xxS_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TMV-24xxx_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TMV-24xxS_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 7.1,    # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.3, +4.75 -7.1 -0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMV-24xxD_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMV-24xxD_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 19.5,   # Package length
         W  = 7.1,    # Package width
@@ -2625,11 +2913,37 @@ all_params = {
         ),
 
 
-    'Converter_DCDC_TRACO_TMV2-xxxxHI_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TMV2-xxxxSHI_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TMV2-xxxxHI_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TMV2-xxxxSHI_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 7.1,    # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.1/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.3, -1.55 -0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMV2-xxxxDHI_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMV2-xxxxDHI_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 19.5,   # Package length
         W  = 7.1,    # Package width
@@ -2657,7 +2971,34 @@ all_params = {
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TMV-xxxxxEN_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TMV-xxxxEN_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 22.0,   # Package length
+        W  = 7.5,    # Package width
+        H  = 12.5,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.5/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-3.5, -2 +0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_DCDC_TRACO_TMV-xxxxDEN_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMV-xxxxDEN_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 22.0,   # Package length
         W  = 7.5,    # Package width
@@ -2760,11 +3101,38 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TRV1-xxxxM_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TRV1-xx1xM_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TRV1-xxxxM_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TRV1-xx1xM_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.6,   # Package length
+        W  = 9.9,    # Package width
+        H  = 12.5,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 9.9/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*pm, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 6*pm, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 8*pm, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (16.0+1.8-19.6, -2.3),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_DCDC_TRACO_TRV1-xx2xM_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TRV1-xx2xM_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 19.6,   # Package length
         W  = 9.9,    # Package width
@@ -2815,6 +3183,7 @@ all_params = {
         pin_color_key      = 'metal grey pins',  # Pin color
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
+
 
     'Converter_DCDC_TRACO_TEC2-xxxxWI_THT': Params(   # ModelName
         #
@@ -2983,11 +3352,37 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TRN1-xxxx_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TRN1-xx1x_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TRN1-xxxx_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TRN1-xx1x_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 11.9,   # Package length
+        W  = 7.7,    # Package width
+        H  = 11.0,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.7/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*pm, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*pm+0.8, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 4*pm+0.8, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (8.8+1.6-11.9,3.7-7.7),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TRN1-xx2x_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TRN1-xx2x_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 11.9,   # Package length
         W  = 7.7,    # Package width
@@ -3010,11 +3405,38 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TRN3-xxxx_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TRN3-xx1x_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TRN3-xxxx_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TRN3-xx1x_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 11.9,   # Package length
+        W  = 7.7,    # Package width
+        H  = 11.0,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 7.7/2 -0.001, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 1*pm, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 2*pm+0.8, 0.0, 0.5, 0.25, 4.1),
+               ('rect', 4*pm+0.8, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
+        pin1corner = (8.8+1.6-11.9,3.7-7.7),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_DCDC_TRACO_TRN3-xx2x_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TRN3-xx2x_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 11.9,   # Package length
         W  = 7.7,    # Package width

--- a/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
@@ -1,5 +1,6 @@
-#!/usr/bin/python
+
 # -*- coding: utf8 -*-
+#!/usr/bin/python
 #
 # This is derived from a cadquery script for generating QFP/GullWings models in X3D format.
 #
@@ -10,14 +11,20 @@
 
 ## file of parametric definitions
 
+class LICENCE_Info():
+
+    ############################################################################
+    # Licence information of the generated models.
+    #################################################################################################
+    STR_licAuthor = "kicad StepUp"
+    STR_licEmail = "ksu"
+    STR_licOrgSys = "kicad StepUp"
+    STR_licPreProc = "OCC"
+    STR_licOrg = "FreeCAD"
+    LIST_license = ["",]
+
 import collections
 from collections import namedtuple
-
-destination_dir="/Converter_DCDC.3dshapes"
-# destination_dir="./"
-old_footprints_dir="Converter_DCDC.pretty"
-footprints_dir="Converter_DCDC.pretty"
-##footprints_dir=None #to exclude importing of footprints
 
 ##enabling optional/default values to None
 def namedtuple_with_defaults(typename, field_names, default_values=()):
@@ -54,6 +61,348 @@ Params = namedtuple_with_defaults("Params", [
 ])
 
 all_params = {
+
+
+
+    'test': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'test',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 20.0,  # Package length
+        W  = 40.0,  # Package width
+        H  = 6,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = (4,2,2), # No rim
+        pin = (
+               ('smd',45, 45.0, 1.0, 1),
+               ('smd',0.0, 0.0, 1.0, 1)),  # Pin placement
+        pin1corner = (0, 0),  # Left upp corner relationsship to pin 1
+        show_top   = True,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 1,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'orange body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'test.3dshapes'  # Destination directory
+        ),
+
+    'Converter_ACDC_Hahn_HS-400xx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_Hahn_HS-400xx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 32.8,  # Package length
+        W  = 27.8,  # Package width
+        H  = 25.8,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round',0.0, 0.0, 1.0, 3.5), ('round',20.0, 0.0, 1.0, 3.5), ('round',15.0, 20.0, 1.0, 3.5), ('round',5.0, 20.0,  1.0, 3.5)),  # Pin placement
+        pin1corner = (-6.4, -3.9),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 1,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_ACDC_MeanWell_IRM-02-xx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_MeanWell_IRM-02-xx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 33.7,  # Package length
+        W  = 22.2,  # Package width
+        H  = 15.0,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round',0.0, 0.0, 1.0, 3.5), ('round',0.0, 15.2, 1.0, 3.5), ('round',28.0, 0.0, 1.0, 3.5), ('round',28.0, 7.6, 1.0, 3.5)),  # Pin placement
+        pin1corner = (-2.85, -3.5),  # Left upp corner relationsship to pin 1
+        show_top   = 0,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 1,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_ACDC_MeanWell_IRM-02-xx_SMD': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_MeanWell_IRM-02-xx_SMD',  # Model name
+        pintype   = 'smd',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 22.2,  # Package length
+        W  = 33.7,  # Package width
+        H  = 16.0,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('smd',-13.2, -13.97, 1.0, 0.4), ('smd',-13.2, -8.89, 1.0, 0.4), ('smd',-13.2, -3.81, 1.0, 0.4), ('smd',-13.2, 6.35, 1.0, 0.4), ('smd',-13.2, 8.89, 1.0, 0.4),\
+               ('smd',-13.2, 11.43, 1.0, 0.4), ('smd',-13.2, 13.97, 1.0, 0.4), ('smd',13.2, -13.97, 1.0, 0.4), ('smd',13.2, -8.89, 1.0, 0.4), ('smd',13.2, -3.81, 1.0, 0.4),\
+               ('smd',13.2, 6.35, 1.0, 0.4), ('smd',13.2, 8.89, 1.0, 0.4), ('smd',13.2, 11.43, 1.0, 0.4), ('smd',13.2, 13.97, 1.0, 0.4)),  # Pin placement
+        pin1corner = (1.0, 3.5),  # Left upp corner relationsship to pin 1
+        show_top   = 0,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 1,  # If belly of caseing should be round (or flat)
+        rotation   = 0.0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_ACDC_MeanWell_IRM-03-xx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_MeanWell_IRM-03-xx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 24.0,  # Package length
+        W  = 37.0,  # Package width
+        H  = 15.0,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round', 0.0, 0.0, 1.0, 3.5), ('round', 0.0, 5.08, 1.0, 3.5), ('round', 0.0, 30.48, 1.0, 3.5), ('round', 17.78, 30.48, 1.0, 3.5), ('round', 17.78, 25.4, 1.0, 3.5)),  # Pin placement
+        pin1corner = (-3.11, -3.26),  # Left upp corner relationsship to pin 1
+        show_top   = 0,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 1,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_ACDC_MeanWell_IRM-03-xx_SMD': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_MeanWell_IRM-03-xx_SMD',  # Model name
+        pintype   = 'smd',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 24.0,  # Package length
+        W  = 37.0,  # Package width
+        H  = 16.0,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('smd',-14.45, -15.24, 1.0, 0.4), ('smd',-14.45, -10.16, 1.0, 0.4), ('smd',-14.45, -5.08, 1.0, 0.4), ('smd',-14.45, 7.62, 1.0, 0.4), ('smd',-14.45, 10.16, 1.0, 0.4),
+               ('smd',-14.45, 12.7, 1.0, 0.4), ('smd',-14.45, 15.24, 1.0, 0.4), ('smd',14.45, -15.24, 1.0, 0.4), ('smd',14.45, -10.16, 1.0, 0.4), ('smd',14.45, -5.08, 1.0, 0.4),
+               ('smd',14.45, 7.62, 1.0, 0.4), ('smd',14.45, 10.16, 1.0, 0.4), ('smd',14.45, 12.7, 1.0, 0.4), ('smd',14.45, 15.24, 1.0, 0.4)),  # Pin placement
+        pin1corner = (1.0, 3.5),  # Left upp corner relationsship to pin 1
+        show_top   = 0,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 1,  # If belly of caseing should be round (or flat)
+        rotation   = 0.0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_ACDC_MeanWell_IRM-20-xx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_MeanWell_IRM-20-xx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 52.4,  # Package length
+        W  = 27.2,  # Package width
+        H  = 24.0,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round',0.0, 0.0, 1.0, 3.5), ('round',0.0, 20.8, 1.0, 3.5), ('round',45.0, 20.8, 1.0, 3.5), ('round',45.0, 12.8, 1.0, 3.5)),  # Pin placement
+        pin1corner = (-3.4, -3.2),  # Left upp corner relationsship to pin 1
+        show_top   = 0,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 1,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_ACDC_Vigortronix_VTX-214-010-xxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_Vigortronix_VTX-214-010-xxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 36.0,  # Package length
+        W  = 56.0,  # Package width
+        H  = 25.5,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round',0.0, 0.0, 1.0, 3.5), ('round',12.0, 0.0, 1.0, 3.5), ('round',0.0, 48.0, 1.0, 3.5), ('round',5.0, 48.0, 1.0, 3.5)),  # Pin placement
+        pin1corner = (-12.0, -4.0),  # Left upp corner relationsship to pin 1
+        show_top   = 0,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 1,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'orange body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_ACDC_Vigortronix_VTX-214-015-1xx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_Vigortronix_VTX-214-015-1xx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 55.0,  # Package length
+        W  = 45.0,  # Package width
+        H  = 24.0,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round',0.0, 0.0, 1.0, 3.5), ('round',0.0, 17.5, 1.0, 3.5), ('round',0.0, 35.0, 1.0, 3.5), ('round',47.0, 27.5, 1.0, 3.5), ('round',47.0, 7.5, 1.0, 3.5)),  # Pin placement
+        pin1corner = (-4.0, -4.0),  # Left upp corner relationsship to pin 1
+        show_top   = 0,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 1,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'orange body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_ACDC_TRACO_TMLM-04_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_TRACO_TMLM-04_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 36.5,  # Package length
+        W  = 27.0,  # Package width
+        H  = 17.1,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round',0.0, 0.0, 1.0, 3.5), ('round',21.5, 0.0, 1.0, 3.5), ('round',25.25, 0.0, 1.0, 3.5), ('round',29.0, 0.0, 1.0, 3.5), ('round',29.0, 21.0, 1.0, 3.5), ('round',21.5, 21.0, 1.0, 3.5), ('round',0.0, 21.0, 1.0, 3.5)),  # Pin placement
+        pin1corner = (-3.75, -3.0),  # Left upp corner relationsship to pin 1
+        show_top   = 1,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'red body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_ACDC_TRACO_TMLM-05_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_TRACO_TMLM-05_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 50.08, # Package length
+        W  = 25.4,  # Package width
+        H  = 15.16, # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round',0.0, 0.0, 1.0, 3.5), ('round',0.0, 10.16, 1.0, 3.5), ('round',45.72, 10.16, 1.0, 3.5), ('round',45.72, -10.16, 1.0, 3.5)),  # Pin placement
+        pin1corner = (-2.54, -12.26),  # Left upp corner relationsship to pin 1
+        show_top   = 1,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'red body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_ACDC_TRACO_TMLM-10-20_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_TRACO_TMLM-10-20_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 52.4,  # Package length
+        W  = 27.2,  # Package width
+        H  = 23.5,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round',0.0, 0.0, 1.0, 3.5), ('round',0.0, 10.16, 1.0, 3.5), ('round',45.72, 10.16, 1.0, 3.5), ('round',45.72, -10.16, 1.0, 3.5)),  # Pin placement
+        pin1corner = (-2.54, -12.26),  # Left upp corner relationsship to pin 1
+        show_top   = 1,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'red body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+
+    'Converter_ACDC_RECOM_RAC04-xxSGx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_RECOM_RAC04-xxSGx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 24.0,  # Package length
+        W  = 37.0,  # Package width
+        H  = 15.0,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round', 0.0, 0.0, 1.0, 3.5), ('round', 0, 5.08, 1.0, 3.5), ('round', 0, 30.48, 1.0, 3.5), ('round', 17.78, 30.48, 1.0, 3.5), ('round', 17.78, 25.4, 1.0, 3.5)),  # Pin placement
+        pin1corner = (-3.11, -3.26),  # Left upp corner relationsship to pin 1
+        show_top   = 0,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 1,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_ACDC_HiLink_HLK-PMxx': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_HiLink_HLK-PMxx',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 34.0,  # Package length
+        W  = 20.2,  # Package width
+        H  = 15.0,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round',0.0, 0.0, 1.0, 3.5), ('round',0, -5.0, 1.0, 3.5), ('round',29.4, -10.2, 1.0, 3.5), ('round',29.4, 5.2, 1.0, 3.5)),  # Pin placement
+        pin1corner = (-2.3, -12.6),  # Left upp corner relationsship to pin 1
+        show_top   = 0,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
     'Converter_DCDC_Cincon_EC5BExx_Single_THT': Params(   # ModelName
         #
         #
@@ -74,8 +423,9 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
+
 
     'Converter_DCDC_Cincon_EC5BExx_Dual_THT': Params(   # ModelName
         #
@@ -97,7 +447,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_Cincon_EC6Cxx_Single_THT': Params(   # ModelName
@@ -119,7 +469,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_Cincon_EC6Cxx_Dual-Triple_THT': Params(   # ModelName
@@ -142,7 +492,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_Bothhand_CFUSxxxx_THT': Params(   # ModelName
@@ -165,7 +515,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'red body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_Bothhand_CFUSxxxxEH_THT': Params(   # ModelName
@@ -188,7 +538,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'red body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_Bothhand_CFUDxxxx_THT': Params(   # ModelName
@@ -211,7 +561,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'red body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_MeanWell_NID30_THT': Params(   # ModelName
@@ -234,7 +584,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_MeanWell_NID60_THT': Params(   # ModelName
@@ -257,7 +607,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_Murata_MEE1SxxxxSC_THT': Params(   # ModelName
@@ -280,7 +630,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_Murata_MEE3SxxxxSC_THT': Params(   # ModelName
@@ -303,7 +653,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_Murata_NCS1SxxxxSC_THT': Params(   # ModelName
@@ -326,7 +676,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_Murata_CRE1xxxxxx3C_THT': Params(   # ModelName
@@ -349,7 +699,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_Murata_CRE1xxxxxxDC_THT': Params(   # ModelName
@@ -372,7 +722,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_Murata_CRE1xxxxxxSC_THT': Params(   # ModelName
@@ -395,7 +745,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_Murata_NMAxxxxDC_THT': Params(   # ModelName
@@ -418,7 +768,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_Murata_NMAxxxxSC_THT': Params(   # ModelName
@@ -440,7 +790,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_Murata_NXE2SxxxxMC_THT': Params(   # ModelName
@@ -463,7 +813,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_RECOM_R-78B-2.0_THT': Params(   # ModelName
@@ -486,7 +836,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_RECOM_R-78E-0.5_THT': Params(   # ModelName
@@ -509,7 +859,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_RECOM_R-78HB-0.5_THT': Params(   # ModelName
@@ -532,7 +882,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_RECOM_R-78S-0.1_THT': Params(   # ModelName
@@ -555,7 +905,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_RECOM_R-78HB-0.5L_THT': Params(   # ModelName
@@ -578,7 +928,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_RECOM_R5xxxDA_THT': Params(   # ModelName
@@ -601,7 +951,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_RECOM_R5xxxPA_THT': Params(   # ModelName
@@ -624,7 +974,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_TRACO_TMR-1SM_SMD': Params(   # ModelName
@@ -647,7 +997,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_TRACO_TMR-1-xxxx_Single_THT': Params(   # ModelName
@@ -670,7 +1020,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_TRACO_TMR-1-xxxx_Dual_THT': Params(   # ModelName
@@ -693,7 +1043,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_TRACO_TMR-xxxx_THT': Params(   # ModelName
@@ -716,7 +1066,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_TRACO_TSR-1_THT': Params(   # ModelName
@@ -739,7 +1089,7 @@ all_params = {
         body_color_key     = 'red body',  # Body color
         body_top_color_key = 'red body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_TRACO_TEN10-xxxx_THT': Params(   # ModelName
@@ -762,7 +1112,7 @@ all_params = {
         body_color_key     = 'metal grey pins',  # Body color
         body_top_color_key = 'red body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_TRACO_TEN10-xxxx_Single_THT': Params(   # ModelName
@@ -785,7 +1135,7 @@ all_params = {
         body_color_key     = 'metal grey pins',  # Body color
         body_top_color_key = 'red body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_TRACO_TEN10-xxxx_Dual_THT': Params(   # ModelName
@@ -808,7 +1158,7 @@ all_params = {
         body_color_key     = 'metal grey pins',  # Body color
         body_top_color_key = 'red body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_TRACO_TEN20-xxxx_THT': Params(   # ModelName
@@ -831,7 +1181,7 @@ all_params = {
         body_color_key     = 'metal grey pins',  # Body color
         body_top_color_key = 'red body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_TRACO_TEN20-xxxx-N4_THT': Params(   # ModelName
@@ -854,7 +1204,7 @@ all_params = {
         body_color_key     = 'metal grey pins',  # Body color
         body_top_color_key = 'red body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_TRACO_TEN20-xxxx_Single_THT': Params(   # ModelName
@@ -877,7 +1227,7 @@ all_params = {
         body_color_key     = 'metal grey pins',  # Body color
         body_top_color_key = 'red body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_TRACO_TEN20-xxxx_Dual_THT': Params(   # ModelName
@@ -900,7 +1250,7 @@ all_params = {
         body_color_key     = 'metal grey pins',  # Body color
         body_top_color_key = 'red body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_XP_POWER_JTExxxxDxx_THT': Params(   # ModelName
@@ -923,7 +1273,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_XP_POWER_ISU02-Series_SMD': Params(   # ModelName
@@ -946,7 +1296,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_Artesyn_ATA-Series_SMD': Params(   # ModelName
@@ -969,7 +1319,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_XP_POWER-IA48xxS_THT': Params(   # ModelName
@@ -994,7 +1344,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_XP_POWER-IAxxxxS_THT': Params(   # ModelName
@@ -1017,7 +1367,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_XP_POWER-IAxxxxD_THT': Params(   # ModelName
@@ -1040,7 +1390,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_XP_POWER-IA48xxD_THT': Params(   # ModelName
@@ -1063,7 +1413,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_XP_POWER-IHxxxxS_THT': Params(   # ModelName
@@ -1086,7 +1436,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_XP_POWER-IHxxxxSH_THT': Params(   # ModelName
@@ -1109,7 +1459,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_XP_POWER-IHxxxxD_THT': Params(   # ModelName
@@ -1132,7 +1482,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_XP_POWER-IHxxxxDH_THT': Params(   # ModelName
@@ -1155,7 +1505,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_XP_POWER-ITQxxxxS-H_THT': Params(   # ModelName
@@ -1178,7 +1528,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_XP_POWER-ITxxxxxS_THT': Params(   # ModelName
@@ -1201,7 +1551,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_XP_POWER-ITXxxxxSA_THT': Params(   # ModelName
@@ -1224,7 +1574,7 @@ all_params = {
         body_color_key     = 'black body',  # Body color
         body_top_color_key = 'black body',  # Body top color
         pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
     'Converter_DCDC_Murata_MGJ2DxxxxxxSC_THT': Params(   # ModelName
@@ -1247,6 +1597,7 @@ all_params = {
         body_color_key     = 'black body',      # Body color
         body_top_color_key = 'black body',      # Body top color
         pin_color_key      = 'metal grey pins', # Pin color
-        dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
+
 }

--- a/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
@@ -2066,7 +2066,7 @@ all_params = {
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TBA1-xxxxHI_Single_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TBA1-xx1xHI_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 19.50,  # Package length
         W  = 6.0,    # Package width
@@ -2223,11 +2223,11 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TMA12xSx_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TMA12xxS_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TMA12xSx_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TMA12xxS_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 19.5,   # Package length
         W  = 6.10,   # Package width
@@ -2249,11 +2249,11 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_TRACO_TMA12xDx_THT': Params(   # ModelName
+    'Converter_DCDC_TRACO_TMA12xxD_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_TRACO_TMA12xDx_THT',  # Model name
+        modelName = 'Converter_DCDC_TRACO_TMA12xxD_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 19.5,   # Package length
         W  = 6.10,   # Package width
@@ -3021,33 +3021,6 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-
-    'Converter_DCDC_TRACO_TMV-xxxxxHI_THT': Params(   # ModelName
-        #
-        #
-        #
-        modelName = 'Converter_DCDC_TRACO_TMV-xxxxxHI_THT',  # Model name
-        pintype   = 'tht',  # Pin type, 'tht', 'smd'
-        L  = 19.5,   # Package length
-        W  = 7.1,    # Package width
-        H  = 10.2,   # Package height
-        A1 = 0.1,    # Package board separation
-        rim = (0.5, 7.1/2 -0.001, 0.5),
-        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
-               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
-               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
-               ('rect', 5*p, 0.0, 0.5, 0.25, 3.2),
-               ('rect', 6*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
-        pin1corner = (-2.3, -1.55-0.25/2),  # Left upp corner relationsship to pin 1
-        show_top   = False,  # If top should be visible or not
-        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
-        roundbelly = 0,  # If belly of caseing should be round (or flat)
-        rotation   = 0,  # If belly of caseing should be round (or flat)
-        body_color_key     = 'black body',  # Body color
-        body_top_color_key = 'black body',  # Body top color
-        pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
-        ),
 
     'Converter_DCDC_TRACO_TRV1-xxxx_THT': Params(   # ModelName
         #

--- a/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
@@ -60,34 +60,9 @@ Params = namedtuple_with_defaults("Params", [
     'dest_dir_prefix'   # Destination directory
 ])
 
+p = 2.54                # no typo error
 all_params = {
 
-
-
-    'test': Params(   # ModelName
-        #
-        #
-        #
-        modelName = 'test',  # Model name
-        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
-        L  = 20.0,  # Package length
-        W  = 40.0,  # Package width
-        H  = 6,  # Package height
-        A1 = 0.1,   # Package board seperation
-        rim = (4,2,2), # No rim
-        pin = (
-               ('smd',45, 45.0, 1.0, 1),
-               ('smd',0.0, 0.0, 1.0, 1)),  # Pin placement
-        pin1corner = (0, 0),  # Left upp corner relationsship to pin 1
-        show_top   = True,  # If top should be visible or not
-        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
-        roundbelly = 1,  # If belly of caseing should be round (or flat)
-        rotation   = 0,  # If belly of caseing should be round (or flat)
-        body_color_key     = 'black body',  # Body color
-        body_top_color_key = 'orange body',  # Body top color
-        pin_color_key      = 'metal grey pins',  # Pin color
-        dest_dir_prefix    = 'test.3dshapes'  # Destination directory
-        ),
 
     'Converter_ACDC_Hahn_HS-400xx_THT': Params(   # ModelName
         #
@@ -380,19 +355,19 @@ all_params = {
         dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_ACDC_HiLink_HLK-PMxx': Params(   # ModelName
+    'Converter_ACDC_HiLink_HLK-PMxx_THT': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_ACDC_HiLink_HLK-PMxx',  # Model name
+        modelName = 'Converter_ACDC_HiLink_HLK-PMxx_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
         L  = 34.0,  # Package length
         W  = 20.2,  # Package width
         H  = 15.0,  # Package height
         A1 = 0.1,   # Package board seperation
         rim = None, # No rim
-        pin = (('round',0.0, 0.0, 1.0, 3.5), ('round',0, -5.0, 1.0, 3.5), ('round',29.4, -10.2, 1.0, 3.5), ('round',29.4, 5.2, 1.0, 3.5)),  # Pin placement
-        pin1corner = (-2.3, -12.6),  # Left upp corner relationsship to pin 1
+        pin = (('round',0.0, 0.0, 1.0, 3.5), ('round',0, 5.0, 1.0, 3.5), ('round',29.4, 10.2, 1.0, 3.5), ('round',29.4, -5.2, 1.0, 3.5)),  # Pin placement
+        pin1corner = (-2.3, -7.5),  # Left upp corner relationsship to pin 1
         show_top   = 0,  # If top should be visible or not
         corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
         roundbelly = 0,  # If belly of caseing should be round (or flat)
@@ -436,7 +411,7 @@ all_params = {
         L  = 25.4,  # Package length
         W  = 50.8,  # Package width
         H  = 10.2,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 1.0, 3.5), ('round', 5.08, 0.0, 1.0, 3.5), ('round', -7.62, 20.32, 1.0, 3.5), ('round', 12.7, 20.32, 1.0, 3.5), ('round', 2.54, 20.32, 1.0, 3.5), ('round', 12.7, 0.0, 1.0, 3.5)),  # Pin placement
         pin1corner = (-10.16, -15.24),  # Left upp corner relationsship to pin 1
@@ -459,7 +434,7 @@ all_params = {
         L  = 50.8,  # Package length
         W  = 50.8,  # Package width
         H  = 24.0,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         pin = (('round', 0.0, 0.0, 1.02, 5.6), ('round', 0.0, 15.24, 1.02, 5.6), ('round', 0.0, 22.86, 1.02, 5.6), ('round', 45.72, 5.08, 1.02, 5.6), ('round', 45.72, 15.24, 1.02, 5.6), ('round', 45.72, 25.4, 1.02, 5.6)),  # Pin placement
         pin1corner = (-2.54, -5.08),  # Left upp corner relationsship to pin 1
         show_top   = False,  # If top should be visible or not
@@ -481,7 +456,7 @@ all_params = {
         L  = 50.8,  # Package length
         W  = 50.8,  # Package width
         H  = 24.0,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 1.02, 5.6), ('round', 0.0, 15.24, 1.02, 5.6), ('round', 0.0, 22.86, 1.02, 5.6), ('round', 45.72, 5.08, 1.02, 5.6), ('round', 45.72, 15.24, 1.02, 5.6), ('round', 45.72, 25.4, 1.02, 5.6), ('round', 45.72, 35.56, 1.02, 5.6)),  # Pin placement
         pin1corner = (-2.54, -5.08),  # Left upp corner relationsship to pin 1
@@ -504,7 +479,7 @@ all_params = {
         L  = 16.8,  # Package length
         W  = 32.6,  # Package width
         H  = 10.2,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.5, 3.5), ('round', 0.0, 22.86, 0.5, 3.5), ('round', 0.0, 25.4, 0.5, 3.5), ('round', 0.0, 27.94, 0.5, 3.5), ('round', 15.24, 27.94, 0.5, 3.5), ('round', 15.24, 25.4, 0.5, 3.5), ('round', 15.24, 22.86, 0.5, 3.5), ('round', 15.24, 0.0, 0.5, 3.5)),  # Pin placement
         pin1corner = (-0.78, -2.65),  # Left upp corner relationsship to pin 1
@@ -527,7 +502,7 @@ all_params = {
         L  = 16.8,  # Package length
         W  = 32.6,  # Package width
         H  = 10.2,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.5, 3.5), ('round', 0.0, 22.86, 0.5, 3.5), ('round', 0.0, 25.4, 0.5, 3.5), ('round', 0.0, 27.94, 0.5, 3.5), ('round', 15.24, 27.94, 0.5, 3.5), ('round', 15.24, 25.4, 0.5, 3.5), ('round', 15.24, 22.86, 0.5, 3.5), ('round', 15.24, 5.08, 0.5, 3.5), ('round', 15.24, 0.0, 0.5, 3.5)),  # Pin placement
         pin1corner = (-0.78, -2.65),  # Left upp corner relationsship to pin 1
@@ -550,7 +525,7 @@ all_params = {
         L  = 16.8,  # Package length
         W  = 32.6,  # Package width
         H  = 10.2,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.5, 3.5), ('round', 0.0, 22.86, 0.5, 3.5), ('round', 0.0, 25.4, 0.5, 3.5), ('round', 0.0, 27.94, 0.5, 3.5), ('round', 15.24, 27.94, 0.5, 3.5), ('round', 15.24, 25.4, 0.5, 3.5), ('round', 15.24, 22.86, 0.5, 3.5), ('round', 15.24, 17.78, 0.5, 3.5), ('round', 15.24, 12.7, 0.5, 3.5), ('round', 15.24, 0.0, 0.5, 3.5)),  # Pin placement
         pin1corner = (-0.78, -2.65),  # Left upp corner relationsship to pin 1
@@ -573,7 +548,7 @@ all_params = {
         L  = 10.7,  # Package length
         W  = 50.8,  # Package width
         H  = 13.0,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.64, 4.5), ('round', 0.0, 2.54, 0.64, 4.5), ('round', 0.0, 5.08, 0.64, 4.5), ('round', 0.0, 7.62, 0.64, 4.5), ('round', 0.0, 10.16, 0.64, 4.5), ('round', 0.0, 35.56, 0.64, 4.5), ('round', 0.0, 38.1, 0.64, 4.5), ('round', 0.0, 40.64, 0.64, 4.5), ('round', 0.0, 43.18, 0.64, 4.5), ('round', 0.0, 45.72, 0.64, 4.5), ('round', 0.0, 48.26, 0.64, 4.5)),  # Pin placement
         pin1corner = (-4.0, -0.92),  # Left upp corner relationsship to pin 1
@@ -596,7 +571,7 @@ all_params = {
         L  = 10.7,  # Package length
         W  = 50.8,  # Package width
         H  = 26.0,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.64, 4.5), ('round', 0.0, 2.54, 0.64, 4.5), ('round', 0.0, 5.08, 0.64, 4.5), ('round', 0.0, 7.62, 0.64, 4.5), ('round', 0.0, 10.16, 0.64, 4.5), ('round', 0.0, 35.56, 0.64, 4.5), ('round', 0.0, 38.1, 0.64, 4.5), ('round', 0.0, 40.64, 0.64, 4.5), ('round', 0.0, 43.18, 0.64, 4.5), ('round', 0.0, 45.72, 0.64, 4.5), ('round', 0.0, 48.26, 0.64, 4.5)),  # Pin placement
         pin1corner = (-4.0, -1.2),  # Left upp corner relationsship to pin 1
@@ -616,8 +591,8 @@ all_params = {
         #
         modelName = 'Converter_DCDC_Murata_MEE1SxxxxSC_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
-        L  = 11.53,  # Package length
-        W  = 6.1,  # Package width
+        L  = 11.53, # Package length
+        W  = 6.1,   # Package width
         H  = 10.0,  # Package height
         A1 = 0.02,  # Package board separation
         rim = (0.4, 0.4, 0.4), # No rim
@@ -639,9 +614,9 @@ all_params = {
         #
         modelName = 'Converter_DCDC_Murata_MEE3SxxxxSC_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
-        L  = 14.15,  # Package length
+        L  = 14.15, # Package length
         W  = 8.15,  # Package width
-        H  = 10.15,  # Package height
+        H  = 10.15, # Package height
         A1 = 0.02,  # Package board separation
         rim = (0.4, 0.4, 0.4), # No rim
         pin = (('rect', 0.0, 0.0, 0.5, 0.25, 4.1), ('rect', 2.54, 0.0, 0.5, 0.25, 4.1), ('rect', 5.08, 0.0, 0.5, 0.25, 4.1), ('rect', 7.62, 0.0, 0.5, 0.25, 4.1)),  # Pin placement
@@ -662,10 +637,10 @@ all_params = {
         #
         modelName = 'Converter_DCDC_Murata_NCS1SxxxxSC_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
-        L  = 21.87,  # Package length
-        W  = 8.2,  # Package width
+        L  = 21.87, # Package length
+        W  = 8.2,   # Package width
         H  = 11.3,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.5, 4.1), ('round', 2.54, 0.0, 0.5, 4.1), ('round', 5.08, 0.0, 0.5, 4.1), ('round', 12.7, 0.0, 0.5, 4.1), ('round', 15.24, 0.0, 0.5, 4.1)),  # Pin placement
         pin1corner = (-2.27, -3.195),  # Left upp corner relationsship to pin 1
@@ -685,10 +660,10 @@ all_params = {
         #
         modelName = 'Converter_DCDC_Murata_CRE1xxxxxx3C_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
-        L  = 6.1,  # Package length
-        W  = 11.53,  # Package width
+        L  = 6.1,   # Package length
+        W  = 11.53, # Package width
         H  = 7.62,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.5, 4.1), ('round', 0.0, 2.54, 0.5, 4.1), ('round', 0.0, 5.08, 0.5, 4.1), ('round', 0.0, 7.62, 0.5, 4.1)),  # Pin placement
         pin1corner = (-1.25, -2.07),  # Left upp corner relationsship to pin 1
@@ -708,10 +683,10 @@ all_params = {
         #
         modelName = 'Converter_DCDC_Murata_CRE1xxxxxxDC_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
-        L  = 9.9,  # Package length
+        L  = 9.9,   # Package length
         W  = 11.6,  # Package width
-        H  = 6.9,  # Package height
-        A1 = 0.1,  # Package board separation
+        H  = 6.9,   # Package height
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.5, 4.1), ('round', 0.0, 7.62, 0.5, 4.1), ('round', 7.62, 7.62, 0.5, 4.1), ('round', 7.62, 2.54, 0.5, 4.1)),  # Pin placement
         pin1corner = (-1.3, -2.1),  # Left upp corner relationsship to pin 1
@@ -731,10 +706,10 @@ all_params = {
         #
         modelName = 'Converter_DCDC_Murata_CRE1xxxxxxSC_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
-        L  = 6.1,  # Package length
-        W  = 11.53,  # Package width
+        L  = 6.1,   # Package length
+        W  = 11.53, # Package width
         H  = 10.0,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.5, 4.1), ('round', 0.0, 2.54, 0.5, 4.1), ('round', 0.0, 5.08, 0.5, 4.1), ('round', 0.0, 7.62, 0.5, 4.1)),  # Pin placement
         pin1corner = (-1.25, -2.07),  # Left upp corner relationsship to pin 1
@@ -754,10 +729,10 @@ all_params = {
         #
         modelName = 'Converter_DCDC_Murata_NMAxxxxDC_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
-        L  = 9.8,  # Package length
+        L  = 9.8,   # Package length
         W  = 19.5,  # Package width
-        H  = 6.8,  # Package height
-        A1 = 0.1,  # Package board separation
+        H  = 6.8,   # Package height
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.5, 4.1), ('round', 0.0, 15.24, 0.5, 4.1), ('round', 7.62, 15.24, 0.5, 4.1), ('round', 7.62, 12.7, 0.5, 4.1), ('round', 7.62, 7.62, 0.5, 4.1), ('round', 7.62, 0.0, 0.5, 4.1)),  # Pin placement
         pin1corner = (-1.22, -2.23),  # Left upp corner relationsship to pin 1
@@ -777,10 +752,10 @@ all_params = {
         #
         modelName = 'Converter_DCDC_Murata_NMAxxxxSC_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
-        L  = 6.0,  # Package length
+        L  = 6.0,   # Package length
         W  = 19.5,  # Package width
         H  = 10.0,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         pin = (('round', 0.0, 0.0, 0.5, 4.1), ('round', 0.0, 2.54, 0.5, 4.1), ('round', 0.0, 7.62, 0.5, 4.1), ('round', 0.0, 10.16, 0.5, 4.1), ('round', 0.0, 12.7, 0.5, 4.1)),  # Pin placement
         pin1corner = (-4.77, -2.03),  # Left upp corner relationsship to pin 1
         show_top   = False,  # If top should be visible or not
@@ -799,10 +774,10 @@ all_params = {
         #
         modelName = 'Converter_DCDC_Murata_NXE2SxxxxMC_THT',  # Model name
         pintype   = 'smd',  # Pin type, 'tht', 'smd'
-        L  = 10.41,  # Package length
+        L  = 10.41, # Package length
         W  = 12.7,  # Package width
         H  = 4.41,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('smd', -4.7, -3.81, 0.61, 0.2), ('smd', -4.7, -1.27, 0.61, 0.2), ('smd', -4.7, 3.81, 0.61, 0.2), ('smd', 4.7, 3.81, 0.61, 0.2), ('smd', 4.7, -3.81, 0.61, 0.2)),  # Pin placement
         pin1corner = (0.0, 0.0),  # Left upp corner relationsship to pin 1
@@ -823,10 +798,10 @@ all_params = {
         modelName = 'Converter_DCDC_RECOM_R-78B-2.0_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 11.5,  # Package length
-        W  = 8.5,  # Package width
+        W  = 8.5,   # Package width
         H  = 17.5,  # Package height
         rim = None, # No rim
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         pin = (('round', 0.0, 0.0, 0.64, 4.1), ('round', 2.54, 0.0, 0.64, 4.1), ('round', 5.08, 0.0, 0.64, 4.1)),  # Pin placement
         pin1corner = (-3.21, -2.0),  # Left upp corner relationsship to pin 1
         show_top   = False,  # If top should be visible or not
@@ -846,9 +821,9 @@ all_params = {
         modelName = 'Converter_DCDC_RECOM_R-78E-0.5_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 11.6,  # Package length
-        W  = 8.5,  # Package width
+        W  = 8.5,   # Package width
         H  = 10.4,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.5, 4.1), ('round', 2.54, 0.0, 0.5, 4.1), ('round', 5.08, 0.0, 0.5, 4.1)),  # Pin placement
         pin1corner = (-3.31, -6.5),  # Left upp corner relationsship to pin 1
@@ -869,9 +844,9 @@ all_params = {
         modelName = 'Converter_DCDC_RECOM_R-78HB-0.5_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 11.5,  # Package length
-        W  = 8.5,  # Package width
+        W  = 8.5,   # Package width
         H  = 17.5,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.7, 4.1), ('round', 2.54, 0.0, 0.7, 4.1), ('round', 5.08, 0.0, 0.7, 4.1)),  # Pin placement
         pin1corner = (-3.21, -2.0),  # Left upp corner relationsship to pin 1
@@ -892,9 +867,9 @@ all_params = {
         modelName = 'Converter_DCDC_RECOM_R-78S-0.1_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 11.6,  # Package length
-        W  = 8.5,  # Package width
+        W  = 8.5,   # Package width
         H  = 10.4,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.7, 4.1), ('round', 2.54, 0.0, 0.7, 4.1), ('round', 5.08, 0.0, 0.7, 4.1), ('round', 7.62, 0.0, 0.7, 4.1)),  # Pin placement
         pin1corner = (-2.0, -6.5),  # Left upp corner relationsship to pin 1
@@ -916,8 +891,8 @@ all_params = {
         pintype   = 'tht_n',  # Pin type, 'tht', 'smd'
         L  = 11.5,  # Package length
         W  = 17.5,  # Package width
-        H  = 8.5,  # Package height
-        A1 = 0.1,  # Package board separation
+        H  = 8.5,   # Package height
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.7, 4.1), ('round', 2.54, 0.0, 0.7, 4.1), ('round', 5.08, 0.0, 0.7, 4.1)),  # Pin placement
         pin1corner = (-3.21, -19.0),  # Left upp corner relationsship to pin 1
@@ -939,8 +914,8 @@ all_params = {
         pintype   = 'tht_n',  # Pin type, 'tht', 'smd'
         L  = 32.2,  # Package length
         W  = 15.0,  # Package width
-        H  = 9.1,  # Package height
-        A1 = 0.1,  # Package board separation
+        H  = 9.1,   # Package height
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.7, 4.1), ('round', 2.54, 0.0, 0.7, 4.1), ('round', 5.08, 0.0, 0.7, 4.1), ('round', 7.62, 0.0, 0.7, 4.1), ('round', 10.16, 0.0, 0.7, 4.1), ('round', 12.7, 0.0, 0.7, 4.1), ('round', 15.24, 0.0, 0.7, 4.1), ('round', 17.78, 0.0, 0.7, 4.1), ('round', 20.32, 0.0, 0.7, 4.1), ('round', 22.86, 0.0, 0.7, 4.1), ('round', 25.4, 0.0, 0.7, 4.1), ('round', 27.94, 0.0, 0.7, 4.1)),  # Pin placement
         pin1corner = (-2.1, -17.0),  # Left upp corner relationsship to pin 1
@@ -961,9 +936,9 @@ all_params = {
         modelName = 'Converter_DCDC_RECOM_R5xxxPA_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 32.2,  # Package length
-        W  = 9.1,  # Package width
+        W  = 9.1,   # Package width
         H  = 15.0,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.7, 4.0), ('round', 2.54, 0.0, 0.7, 4.0), ('round', 5.08, 0.0, 0.7, 4.0), ('round', 7.62, 0.0, 0.7, 4.0), ('round', 10.16, 0.0, 0.7, 4.0), ('round', 12.7, 0.0, 0.7, 4.0), ('round', 15.24, 0.0, 0.7, 4.0), ('round', 17.78, 0.0, 0.7, 4.0), ('round', 20.32, 0.0, 0.7, 4.0), ('round', 22.86, 0.0, 0.7, 4.0), ('round', 25.4, 0.0, 0.7, 4.0), ('round', 27.94, 0.0, 0.7, 4.0)),  # Pin placement
         pin1corner = (-2.1, -0.8),  # Left upp corner relationsship to pin 1
@@ -979,17 +954,23 @@ all_params = {
 
     'Converter_DCDC_TRACO_TMR-1SM_SMD': Params(   # ModelName
         #
-        #
+        # reminder: for pintype='smd', (0,0) is the center of the device
         #
         modelName = 'Converter_DCDC_TRACO_TMR-1SM_SMD',  # Model name
         pintype   = 'smd',  # Pin type, 'tht', 'smd'
         L  = 13.7,  # Package length
         W  = 18.9,  # Package width
         H  = 8.45,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
-        pin = (('round', -8.075, -7.62, 0.2, 1.2), ('round', -8.075, -5.08, 0.2, 1.2), ('round', -8.075, 5.08, 0.2, 1.2), ('round', -8.075, 7.62, 0.2, 1.2), ('round', 8.075, -7.62, 0.2, 1.2), ('round', 8.075, 5.08, 0.2, 1.2), ('round', 8.075, 7.62, 0.2, 1.2)),  # Pin placement
-        pin1corner = (0.0, 0.0),  # Left upp corner relationsship to pin 1
+        pin = (('smd', -8.075, -3*p, 1.0, 0.4),
+               ('smd', -8.075, -2*p, 1.0, 0.4),
+               ('smd', -8.075,  2*p, 1.0, 0.4),
+               ('smd', -8.075,  3*p, 1.0, 0.4),
+               ('smd',  8.075, -3*p, 1.0, 0.4),
+               ('smd',  8.075,  2*p, 1.0, 0.4),
+               ('smd',  8.075,  3*p, 1.0, 0.4)),  # Pin placement
+        pin1corner = (0.0, 0.0),  # Left up corner relationsship to pin 1
         show_top   = False,  # If top should be visible or not
         corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
         roundbelly = 1,  # If belly of caseing should be round (or flat)
@@ -1009,10 +990,14 @@ all_params = {
         L  = 17.0,  # Package length
         W  = 7.62,  # Package width
         H  = 11.0,  # Package height
-        A1 = 0.1,  # Package board separation
-        rim = None, # No rim
-        pin = (('round', 0.0, 0.0, 0.5, 3.2), ('round', 2.54, 0.0, 0.5, 3.2), ('round', 7.62, 0.0, 0.5, 3.2), ('round', 12.7, 0.0, 0.5, 3.2)),  # Pin placement
-        pin1corner = (-2.3, -2.5),  # Left upp corner relationsship to pin 1
+        A1 = 0.1,   # Package board separation
+        rim = (1, 3, 0.5), # No rim
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.3, -2.5-0.25/2),  # Left upp corner relationsship to pin 1
         show_top   = False,  # If top should be visible or not
         corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
         roundbelly = 0,  # If belly of caseing should be round (or flat)
@@ -1032,10 +1017,14 @@ all_params = {
         L  = 17.0,  # Package length
         W  = 7.62,  # Package width
         H  = 11.0,  # Package height
-        A1 = 0.1,  # Package board separation
-        rim = None, # No rim
-        pin = (('round', 0.0, 0.0, 0.5, 3.2), ('round', 2.54, 0.0, 0.5, 3.2), ('round', 7.62, 0.0, 0.5, 3.2), ('round', 10.16, 0.0, 0.5, 3.2), ('round', 12.7, 0.0, 0.5, 3.2)),  # Pin placement
-        pin1corner = (-2.3, -2.5),  # Left upp corner relationsship to pin 1
+        A1 = 0.1,   # Package board separation
+        rim = (1, 3, 0.5), # No rim
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.3, -2.5-0.25/2),  # Left upp corner relationsship to pin 1
         show_top   = False,  # If top should be visible or not
         corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
         roundbelly = 0,  # If belly of caseing should be round (or flat)
@@ -1053,9 +1042,9 @@ all_params = {
         modelName = 'Converter_DCDC_TRACO_TMR-xxxx_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 21.8,  # Package length
-        W  = 9.2,  # Package width
+        W  = 9.2,   # Package width
         H  = 11.0,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.5, 4.0), ('round', 2.54, 0.0, 0.5, 4.0), ('round', 5.08, 0.0, 0.5, 4.0), ('round', 10.16, 0.0, 0.5, 4.0), ('round', 12.7, 0.0, 0.5, 4.0), ('round', 15.24, 0.0, 0.5, 4.0), ('round', 17.78, 0.0, 0.5, 4.0)),  # Pin placement
         pin1corner = (-2.0, -3.2),  # Left upp corner relationsship to pin 1
@@ -1069,6 +1058,7 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
+
     'Converter_DCDC_TRACO_TSR-1_THT': Params(   # ModelName
         #
         #
@@ -1076,9 +1066,9 @@ all_params = {
         modelName = 'Converter_DCDC_TRACO_TSR-1_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 11.7,  # Package length
-        W  = 7.6,  # Package width
+        W  = 7.6,   # Package width
         H  = 10.2,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.5, 4.0), ('round', 2.54, 0.0, 0.5, 4.0), ('round', 5.08, 0.0, 0.5, 4.0)),  # Pin placement
         pin1corner = (-3.3, -5.6),  # Left upp corner relationsship to pin 1
@@ -1101,7 +1091,7 @@ all_params = {
         L  = 25.4,  # Package length
         W  = 50.8,  # Package width
         H  = 10.2,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 1.0, 6.0), ('round', 5.08, 0.0, 1.0, 6.0), ('round', -7.62, 20.32, 1.0, 6.0), ('round', 12.7, 20.32, 1.0, 6.0)),  # Pin placement
         pin1corner = (-10.12, -15.2),  # Left upp corner relationsship to pin 1
@@ -1124,7 +1114,7 @@ all_params = {
         L  = 25.4,  # Package length
         W  = 50.8,  # Package width
         H  = 10.2,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 1.0, 6.0), ('round', 5.08, 0.0, 1.0, 6.0), ('round', -7.62, 20.32, 1.0, 6.0), ('round', 12.7, 20.32, 1.0, 6.0)),  # Pin placement
         pin1corner = (-10.12, -15.2),  # Left upp corner relationsship to pin 1
@@ -1147,7 +1137,7 @@ all_params = {
         L  = 25.4,  # Package length
         W  = 50.8,  # Package width
         H  = 10.2,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 1.0, 6.0), ('round', 5.08, 0.0, 1.0, 6.0), ('round', -7.62, 20.32, 1.0, 6.0), ('round', 2.54, 20.32, 1.0, 6.0), ('round', 12.7, 20.32, 1.0, 6.0)),  # Pin placement
         pin1corner = (-10.12, -15.2),  # Left upp corner relationsship to pin 1
@@ -1170,7 +1160,7 @@ all_params = {
         L  = 25.4,  # Package length
         W  = 50.8,  # Package width
         H  = 10.2,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 1.0, 6.0), ('round', 5.08, 0.0, 1.0, 6.0), ('round', -7.62, 20.32, 1.0, 6.0), ('round', 2.54, 20.32, 1.0, 6.0), ('round', 12.7, 20.32, 1.0, 6.0), ('round', 12.7, 0.0, 1.0, 6.0)),  # Pin placement
         pin1corner = (-10.16, -15.24),  # Left upp corner relationsship to pin 1
@@ -1193,7 +1183,7 @@ all_params = {
         L  = 25.4,  # Package length
         W  = 50.8,  # Package width
         H  = 10.2,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 1.0, 6.0), ('round', 5.08, 0.0, 1.0, 6.0), ('round', -7.62, 20.32, 1.0, 6.0), ('round', 12.7, 20.32, 1.0, 6.0), ('round', 12.7, 0.0, 1.0, 6.0)),  # Pin placement
         pin1corner = (-10.16, -15.24),  # Left upp corner relationsship to pin 1
@@ -1216,7 +1206,7 @@ all_params = {
         L  = 25.4,  # Package length
         W  = 50.8,  # Package width
         H  = 10.2,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 1.0, 6.0), ('round', 5.08, 0.0, 1.0, 6.0), ('round', -7.62, 20.32, 1.0, 6.0), ('round', 12.7, 20.32, 1.0, 6.0), ('round', 12.7, 0.0, 1.0, 6.0)),  # Pin placement
         pin1corner = (-10.16, -15.24),  # Left upp corner relationsship to pin 1
@@ -1239,7 +1229,7 @@ all_params = {
         L  = 25.4,  # Package length
         W  = 50.8,  # Package width
         H  = 10.2,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 1.0, 6.0), ('round', 5.08, 0.0, 1.0, 6.0), ('round', -7.62, 20.32, 1.0, 6.0), ('round', 2.54, 20.32, 1.0, 6.0), ('round', 12.7, 20.32, 1.0, 6.0), ('round', 12.7, 0.0, 1.0, 6.0)),  # Pin placement
         pin1corner = (-10.16, -15.24),  # Left upp corner relationsship to pin 1
@@ -1259,10 +1249,10 @@ all_params = {
         #
         modelName = 'Converter_DCDC_XP_POWER_JTExxxxDxx_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
-        L  = 20.32,  # Package length
-        W  = 31.75,  # Package width
+        L  = 20.32, # Package length
+        W  = 31.75, # Package width
         H  = 10.4,  # Package height
-        A1 = 0.1,  # Package board separation
+        A1 = 0.1,   # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.5, 3.05), ('round', 0.0, 17.78, 0.5, 3.05), ('round', 0.0, 22.86, 0.5, 3.05), ('round', 15.24, 22.86, 0.5, 3.05), ('round', 15.24, 17.78, 0.5, 3.05), ('round', 15.24, 0.0, 0.5, 3.05), ('round', 0.0, 2.54, 0.5, 3.05), ('round', 15.24, 2.54, 0.5, 3.05)),  # Pin placement
         pin1corner = (-2.54, -4.445),  # Left upp corner relationsship to pin 1
@@ -1285,7 +1275,7 @@ all_params = {
         L  = 14.9,  # Package length
         W  = 19.0,  # Package width
         H  = 8.50,  # Package height
-        A1 = 0.2,  # Package board separation
+        A1 = 0.2,   # Package board separation
         rim = None, # No rim
         pin = (('smd', -8.075, -7.62, 1.2, 0.2), ('smd', -8.075, -5.08, 1.2, 0.2), ('smd', -8.075, 5.08, 1.2, 0.2), ('smd', -8.075, 7.62, 1.2, 0.2), ('smd', 8.075, -7.62, 1.2, 0.2), ('smd', 8.075, 5.08, 1.2, 0.2), ('smd', 8.075, 7.62, 1.2, 0.2)),  # Pin placement
         pin1corner = (0.0, 0.0),  # Left upp corner relationsship to pin 1
@@ -1307,7 +1297,7 @@ all_params = {
         pintype   = 'smd',  # Pin type, 'tht', 'smd'
         L  = 13.7,  # Package length
         W  = 24.0,  # Package width
-        H  = 8.0,  # Package height
+        H  = 8.0,   # Package height
         A1 = 0.25,  # Package board separation
         rim = None, # No rim
         pin = (('smd', -8.25, -8.89, 1.2, 0.2), ('smd', -8.25, -6.35, 1.2, 0.2), ('smd', -8.25, 6.35, 1.2, 0.2), ('smd', -8.25, 8.89, 1.2, 0.2), ('smd', 8.25, 8.89, 1.2, 0.2), ('smd', 8.25, 6.35, 1.2, 0.2), ('smd', 8.25, -8.89, 1.2, 0.2)),  # Pin placement
@@ -1328,10 +1318,10 @@ all_params = {
         #
         modelName = 'Converter_DCDC_XP_POWER-IA48xxS_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
-        L  = 7.20-0.5,  # Package length
+        L  = 7.20-0.5,   # Package length
         W  = 19.30-0.5,  # Package width
-        H  = 10.16,  # Package height
-        A1 = 0.01,  # Package board separation
+        H  = 10.16,      # Package height
+        A1 = 0.01,       # Package board separation
         rim = (0.0, 0.5, 0.5),  # If a rim should be created at the bottom
         pin = (('round', 0.0, 0.0, 0.51, 3.05), ('round', 0.0, 2.54, 0.51, 3.05), ('round', 0.0, 7.62, 0.51, 3.05), ('round', 0.0, 10.16, 0.51, 3.05), ('round', 0.0, 12.70, 0.51, 3.05)),  # Pin placement
         pin1corner = (-5.80+0.5, -1.53),  # Left upp corner relationsship to pin 1
@@ -1353,10 +1343,10 @@ all_params = {
         #
         modelName = 'Converter_DCDC_XP_POWER-IAxxxxS_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
-        L  = 6.09-0.5,  # Package length
+        L  = 6.09-0.5,   # Package length
         W  = 19.30-0.5,  # Package width
-        H  = 10.16,  # Package height
-        A1 = 0.01,  # Package board separation
+        H  = 10.16,      # Package height
+        A1 = 0.01,       # Package board separation
         rim = (0.0, 0.5, 0.5),  # If a rim should be created at the bottom
         pin = (('round', 0.0, 0.0, 0.51, 3.05), ('round', 0.0, 2.54, 0.51, 3.05), ('round', 0.0, 7.62, 0.51, 3.05), ('round', 0.0, 10.16, 0.51, 3.05), ('round', 0.0, 12.70, 0.51, 3.05)),  # Pin placement
         pin1corner = (-4.69+0.5, -1.53),  # Left upp corner relationsship to pin 1
@@ -1378,8 +1368,8 @@ all_params = {
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 10.16-0.5,  # Package length
         W  = 20.32-0.5,  # Package width
-        H  = 6.35-0.5,  # Package height
-        A1 = 0.01,  # Package board separation
+        H  = 6.35-0.5,   # Package height
+        A1 = 0.01,       # Package board separation
         rim = None, # No rim
         pin = (('round', 0.0, 0.0, 0.51, 2.79), ('round', 0.0, 15.24, 0.51, 2.79), ('round', 7.62, 0.0, 0.51, 2.79), ('round', 7.62, 7.62, 0.51, 2.79), ('round', 7.62, 12.70, 0.51, 2.79), ('round', 7.62, 15.24, 0.51, 2.79)),  # Pin placement
         pin1corner = (-1.27+0.25, -2.54+0.25),  # Left upp corner relationsship to pin 1
@@ -1401,9 +1391,9 @@ all_params = {
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 10.16-0.5,  # Package length
         W  = 20.32-0.5,  # Package width
-        H  = 6.88-0.5,  # Package height
-        A1 = 0.01,  # Package board separation
-        rim = None, # No rim
+        H  = 6.88-0.5,   # Package height
+        A1 = 0.01,       # Package board separation
+        rim = None,      # No rim
         pin = (('round', 0.0, 0.0, 0.51, 2.79), ('round', 0.0, 15.24, 0.51, 2.79), ('round', 7.62, 0.0, 0.51, 2.79), ('round', 7.62, 7.62, 0.51, 2.79), ('round', 7.62, 12.70, 0.51, 2.79), ('round', 7.62, 15.24, 0.51, 2.79)),  # Pin placement
         pin1corner = (-1.27+0.25, -2.54+0.25),  # Left upp corner relationsship to pin 1
         show_top   = False,  # If top should be visible or not
@@ -1422,10 +1412,10 @@ all_params = {
         #
         modelName = 'Converter_DCDC_XP_POWER-IHxxxxS_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
-        L  = 7.2-0.5,  # Package length
-        W  = 19.5-0.5,  # Package width
-        H  = 10.16,  # Package height
-        A1 = 0.01,  # Package board separation
+        L  = 7.2-0.5,    # Package length
+        W  = 19.5-0.5,   # Package width
+        H  = 10.16,      # Package height
+        A1 = 0.01,       # Package board separation
         rim = (0.0, 0.38, 0.38),  # If a rim should be created at the bottom
         pin = (('round', 0.0, 0.0, 0.5, 3.00), ('round', 0.0, 2.54, 0.5, 3.00), ('round', 0.0, 7.62, 0.5, 3.00), ('round', 0.0, 10.16, 0.5, 3.00), ('round', 0.0, 12.70, 0.5, 3.00)),  # Pin placement
         pin1corner = (-5.95+0.5, -2.29),  # Left upp corner relationsship to pin 1
@@ -1445,10 +1435,10 @@ all_params = {
         #
         modelName = 'Converter_DCDC_XP_POWER-IHxxxxSH_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
-        L  = 7.62-0.5,  # Package length
-        W  = 19.5-0.5,  # Package width
+        L  = 7.62-0.5,   # Package length
+        W  = 19.5-0.5,   # Package width
         H  = 10.16-0.5,  # Package height
-        A1 = 0.01,  # Package board separation
+        A1 = 0.01,       # Package board separation
         rim = (0.0, 0.38, 0.38),  # If a rim should be created at the bottom
         pin = (('round', 0.0, 0.0, 0.5, 3.00), ('round', 0.0, 2.54, 0.5, 3.00), ('round', 0.0, 10.16, 0.5, 3.00), ('round', 0.0, 12.70, 0.5, 3.00), ('round', 0.0, 15.24, 0.5, 3.00)),  # Pin placement
         pin1corner = (-6.37+0.5, -2.29),  # Left upp corner relationsship to pin 1
@@ -1470,9 +1460,9 @@ all_params = {
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 10.16-0.5,  # Package length
         W  = 20.32-0.5,  # Package width
-        H  = 6.88,  # Package height
-        A1 = 0.01,  # Package board separation
-        rim = None, # No rim
+        H  = 6.88,       # Package height
+        A1 = 0.01,       # Package board separation
+        rim = None,      # No rim
         pin = (('round', 0.0, 0.0, 0.51, 2.79), ('round', 0.0, 15.24, 0.51, 2.79), ('round', 7.62, 0.0, 0.51, 2.79), ('round', 7.62, 7.62, 0.51, 2.79), ('round', 7.62, 12.70, 0.51, 2.79), ('round', 7.62, 15.24, 0.51, 2.79)),  # Pin placement
         pin1corner = (-1.27+0.25, -2.54+0.25),  # Left upp corner relationsship to pin 1
         show_top   = False,  # If top should be visible or not
@@ -1493,9 +1483,9 @@ all_params = {
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 10.16-0.5,  # Package length
         W  = 20.32-0.5,  # Package width
-        H  = 6.88,  # Package height
-        A1 = 0.01,  # Package board separation
-        rim = None, # No rim
+        H  = 6.88,       # Package height
+        A1 = 0.01,       # Package board separation
+        rim = None,      # No rim
         pin = (('round', 0.0, 0.0, 0.51, 2.79), ('round', 0.0, 15.24, 0.51, 2.79), ('round', 7.62, 0.0, 0.51, 2.79), ('round', 7.62, 10.16, 0.51, 2.79), ('round', 7.62, 12.70, 0.51, 2.79), ('round', 7.62, 15.24, 0.51, 2.79)),  # Pin placement
         pin1corner = (-1.27+0.25, -2.54+0.25),  # Left upp corner relationsship to pin 1
         show_top   = False,  # If top should be visible or not
@@ -1514,10 +1504,10 @@ all_params = {
         #
         modelName = 'Converter_DCDC_XP_POWER-ITQxxxxS-H_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
-        L  = 9.20,  # Package length
+        L  = 9.20,   # Package length
         W  = 21.85,  # Package width
         H  = 10.65,  # Package height
-        A1 = 0.01,  # Package board separation
+        A1 = 0.01,   # Package board separation
         rim = (0.0, 0.38, 0.38),  # If a rim should be created at the bottom
         pin = (('round', 0.0, 0.0, 0.5, 3.00), ('round', 0.0, 2.54, 0.5, 3.00), ('round', 0.0, 5.08, 0.5, 3.00), ('round', 0.0, 12.70, 0.5, 3.00), ('round', 0.0, 15.24, 0.5, 3.00), ('round', 0.0, 17.78, 0.5, 3.00)),  # Pin placement
         pin1corner = (-6.00, -2.035),  # Left upp corner relationsship to pin 1
@@ -1537,10 +1527,10 @@ all_params = {
         #
         modelName = 'Converter_DCDC_XP_POWER-ITxxxxxS_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
-        L  = 9.20,  # Package length
+        L  = 9.20,   # Package length
         W  = 21.85,  # Package width
         H  = 10.65,  # Package height
-        A1 = 0.01,  # Package board separation
+        A1 = 0.01,   # Package board separation
         rim = (0.0, 0.38, 0.38),  # If a rim should be created at the bottom
         pin = (('round', 0.0, 0.0, 0.5, 3.00), ('round', 0.0, 2.54, 0.5, 3.00), ('round', 0.0, 5.08, 0.5, 3.00), ('round', 0.0, 10.16, 0.5, 3.00), ('round', 0.0, 12.70, 0.5, 3.00), ('round', 0.0, 15.24, 0.5, 3.00), ('round', 0.0, 17.78, 0.5, 3.00)),  # Pin placement
         pin1corner = (-6.00, -2.035),  # Left upp corner relationsship to pin 1
@@ -1561,8 +1551,8 @@ all_params = {
         modelName = 'Converter_DCDC_XP_POWER-ITXxxxxSA_THT',  # Model name
         pintype   = 'tht',  # Pin type, 'tht', 'smd'
         L  = 9.20,  # Package length
-        W  = 21.85,  # Package width
-        H  = 10.65,  # Package height
+        W  = 21.85, # Package width
+        H  = 10.65, # Package height
         A1 = 0.01,  # Package board separation
         rim = (0.0, 0.38, 0.38),  # If a rim should be created at the bottom
         pin = (('round', 0.0, 0.0, 0.5, 3.00), ('round', 0.0, 2.54, 0.5, 3.00), ('round', 0.0, 12.70, 0.5, 3.00), ('round', 0.0, 15.24, 0.5, 3.00), ('round', 0.0, 17.78, 0.5, 3.00)),  # Pin placement
@@ -1583,12 +1573,16 @@ all_params = {
         #
         modelName = 'Converter_DCDC_Murata_MGJ2DxxxxxxSC_THT',  # Model name
         pintype   = 'tht',      # Pin type, 'tht', 'smd'
-        L  = 10.42,             # Package length
-        W  = 19.50,             # Package width
+        L  = 19.50,             # Package length
+        W  = 9.80,              # Package width
         H  = 12.50,             # Package height
         A1 = 0.01,              # Package board separation
         rim = (0.0, 0.4, 0.4),  # If a rim should be created at the bottom
-        pin = (('rect', 0.0, 0.0, 0.25, 0.5, 4.1), ('rect', 0.0, 2.54, 0.25, 0.5, 4.1), ('rect', 0.0, 10.16, 0.25, 0.5, 4.1), ('rect', 0.0, 12.70, 0.25, 0.5, 4.1), ('rect', 0.0, 15.24, 0.25, 0.5, 4.1)),  # Pin placement
+        pin = (('rect', 0.0, 0.0,  0.25, 0.5, 4.1),
+               ('rect', 2.54,0.0,  0.25, 0.5, 4.1),
+               ('rect', 10.16,0.0, 0.25, 0.5, 4.1),
+               ('rect', 12.70,0.0, 0.25, 0.5, 4.1),
+               ('rect', 15.24,0.0, 0.25, 0.5, 4.1)),  # Pin placement
         pin1corner = (-2.13, -2.67),  # Left upp corner relationsship to pin 1
         show_top   = False,     # If top should be visible or not
         corner     = 'fillet',  # If top should be cut, 'none', 'chamfer' or 'fillet'
@@ -1597,6 +1591,360 @@ all_params = {
         body_color_key     = 'black body',      # Body color
         body_top_color_key = 'black body',      # Body top color
         pin_color_key      = 'metal grey pins', # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_THD_15-xxxxWIN_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_THD_15-xxxxWIN_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 20.3,  # Package length
+        W  = 31.8,  # Package width
+        H  = 10.2,  # Package height
+        A1 = 0.1,   # Package board separation
+        rim = None, # No rim
+        pin = (
+              ('round', 0*p, 0*p, 0.5, 3.8),
+              ('round', 0*p, 1*p, 0.5, 3.8),
+              ('round', 0*p, 2*p, 0.5, 3.8),
+              ('round', 0*p, 8*p, 0.5, 3.8),
+              ('round', 0*p,10*p, 0.5, 3.8),
+              ('round', 6*p, 1*p, 0.5, 3.8),
+              ('round', 6*p, 2*p, 0.5, 3.8),
+              ('round', 6*p, 8*p, 0.5, 3.8),
+              ('round', 6*p,10*p, 0.5, 3.8)),  # Pin placement
+        pin1corner = (-2.5, -2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 1,  # If belly of caseing should be round (or flat)
+        rotation   = 0.0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'white body',  # Body color
+        body_top_color_key = 'white body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_ACDC_MeanWell_IRM-05-xx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_MeanWell_IRM-05-xx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 45.7 , # Package length
+        W  = 25.4,  # Package width
+        H  = 21.5,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round',0.0, 0.0, 1.04, 3.5),
+               ('round',0.0 , 10.75, 1.04, 3.5),
+               ('round',38.5, 10.75-8, 1.04, 3.5),
+               ('round',38.5, 10.75, 1.04, 3.5)),  # Pin placement
+        pin1corner = (-3.6, -25.4+10.75+3.45),  # Left upp corner relationsship to pin 1
+        show_top   = 0,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 1,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_ACDC_MeanWell-IRM-10-xx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_MeanWell-IRM-10-xx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 45.7 , # Package length
+        W  = 25.4,  # Package width
+        H  = 21.5,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round',0.0, 0.0, 1.04, 3.5),
+               ('round',0.0 , 10.75, 1.04, 3.5),
+               ('round',38.5, 10.75-8, 1.04, 3.5),
+               ('round',38.5, 10.75, 1.04, 3.5)),  # Pin placement
+        pin1corner = (-3.6, -25.4+10.75+3.45),  # Left upp corner relationsship to pin 1
+        show_top   = 0,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 1,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_ACDC_MeanWell_IRM-60-xx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_MeanWell_IRM-60-xx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 87.0 , # Package length
+        W  = 52.0,  # Package width
+        H  = 29.5,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round',0.0, 0.0, 1.0, 3.5),
+               ('round',0.0 , 6.75, 1.0, 3.5),
+               ('round',76.0, -5+40.75, 2.0, 3.5),
+               ('round',76.0, -5+40.75+5.5, 2.0, 3.5)),  # Pin placement
+        pin1corner = (-5.7, -5.0 ),  # Left upp corner relationsship to pin 1
+        show_top   = 0,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 1,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_ACDC_RECOM_RAC04-xxSK_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_RECOM_RAC05-xxSK_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 25.4,  # Package length
+        W  = 25.4,  # Package width
+        H  = 16.5,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = ( ('round', 0.0, 0.0, 0.51, 5.0),
+                ('round', 0, 3.90, 0.51, 5.0),
+                ('round', -20.76, 3.90+1.29, 0.51, 5.0),
+                ('round', -20.76, 3.90+1.29-10.16, 0.51, 5.0),
+                ('round', -20.76, 3.90+1.29-21.59, 0.51, 5.0)),  # Pin placement
+        pin1corner = ( -25.4+2.70, -25.4+3.90+3.13),  # Left upp corner relationsship to pin 1
+        show_top   = 0,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 1,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_ACDC_TRACO_TMG-15xxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_TRACO_TMG-15xxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 41.2,  # Package length
+        W  = 27.2,  # Package width
+        H  = 19.1,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round',0.0, 0.0, 1.0, 8.0),
+               ('round',0.0, 19.0, 1.0, 8.0),
+               ('round',33., 0.0, 1.0, 8.0),
+               ('round',33.0, 12.7, 1.0, 8.0)),  # Pin placement
+        pin1corner = (-4.1, -3.4),  # Left upp corner relationsship to pin 1
+        show_top   = 1,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_ACDC_TRACO_TMG-7xxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_TRACO_TMG-7xxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 27.4,  # Package length
+        W  = 27.4,  # Package width
+        H  = 18.7,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round',0.0, 0.0, 0.6, 4.0),
+               ('round',0.0, 5.0, 0.6, 4.0),
+               ('round',20.8, 0.0, 0.6, 4.0),
+               ('round',20.8, 10.2, 0.6, 4.0)),  # Pin placement
+        pin1corner = (-4.1, -3.4),  # Left upp corner relationsship to pin 1
+        show_top   = 1,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_ACDC_TRACO_TMG-30xxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_TRACO_TMG-30xxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 64.0,  # Package length
+        W  = 45.0,  # Package width
+        H  = 23.5,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round',0.0, 0.0, 1.0, 8.0),
+               ('round',0.0, 17.5, 1.0, 8.0),
+               ('round',54.0, -10.0, 1.0, 8.0),
+               ('round',54.0, 10.0, 1.0, 8.0)),  # Pin placement
+        pin1corner = (-4.0, -22.5),  # Left upp corner relationsship to pin 1
+        show_top   = 1,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_ACDC_TRACO_TMG-50xxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_TRACO_TMG-50xxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd', 'thtsmd' or 'tht_n'
+        L  = 74.1,  # Package length
+        W  = 54.1,  # Package width
+        H  = 21.8,  # Package height
+        A1 = 0.1,   # Package board seperation
+        rim = None, # No rim
+        pin = (('round',0.0, 0.0, 1.0, 8.0),
+               ('round',0.0, 20.0, 1.0, 8.0),
+               ('round',62.0, -27.05+15.55, 1.0, 8.0),
+               ('round',62.0, -27.05+15.55+23, 1.0, 8.0)),  # Pin placement
+        pin1corner = (-6.05, -27.5),  # Left upp corner relationsship to pin 1
+        show_top   = 1,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_RECOM_RPA60-xxxxSFW_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_RECOM_RPA60-xxxxSFW_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 10*p,  # Package length
+        W  = 20*p,  # Package width
+        H  = 10.2,  # Package height
+        A1 = 0.1,   # Package board separation
+        rim = None, # No rim
+        pin = (('round',  0*p,  0*p, 1.0, 5.6),
+               ('round',  2*p,  0*p, 1.0, 5.6),
+               ('round',  6*p,  0*p, 1.0, 5.6),
+               ('round',  7*p, 18*p, 1.0, 5.6),
+               ('round',  3*p, 18*p, 1.0, 5.6),
+               ('round', -1*p, 18*p, 1.0, 5.6)),  # Pin placement
+        pin1corner = (-2*p, -1*p),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TDN_5-xxxxWISM_SMD': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TDN_5-xxxxWISM_SMD',  # Model name
+        pintype   = 'smd',  # Pin type, 'tht', 'smd'
+        W  = 13.2,  # Package length
+        L  = 9.1,   # Package width
+        H  = 10.2,  # Package height
+        A1 = 0.1,   # Package board separation
+        rim = None, # No rim
+        pin = (('smd',  3+0.3, -7.1, 0.6, 0.25),
+               ('smd', -1+0.3, -7.1, 0.6, 0.25),
+               ('smd', -3+0.3, -7.1, 0.6, 0.25),
+               ('smd',  1+0.3,  7.1, 0.6, 0.25),
+               ('smd', -1+0.3,  7.1, 0.6, 0.25),
+               ('smd', -3+0.3,  7.1, 0.6, 0.25)),  # Pin placement
+        pin1corner = (0.0, 0.0),  # Left up corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 1,  # If belly of caseing should be round (or flat)
+        rotation   = 0.0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMR-2xxxxWI_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMR-2xxxxWI_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 25.95,  # Package length
+        W  = 9.25,   # Package width
+        H  = 12.45,  # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (1, 3, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 7*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 8*p, 0.0, 0.5, 0.25, 3.2)),  # Pin placement
+        pin1corner = (-2.0, -3.0 -0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_XP_POWER_JTDxxxxxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_XP_POWER_JTDxxxxxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 25.4,  # Package length
+        W  = 40.64, # Package width
+        H  = 10.4,  # Package height
+        A1 = 0.1,   # Package board separation
+        rim = (0.4, 0.4, 0.5),
+        pin = (('round', 0*p, 0*p, 1.0, 6.0),
+               ('round', 2*p, 0*p, 1.0, 6.0),
+               ('round', 5*p, 0*p, 1.0, 6.0),
+               ('round',-3*p, 8*p, 1.0, 6.0),
+               ('round', 1*p, 8*p, 1.0, 6.0),
+               ('round', 5*p, 8*p, 1.0, 6.0)),  # Pin placement
+        pin1corner = (-4*p, -4*p),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 

--- a/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
@@ -1948,4 +1948,360 @@ all_params = {
         dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
         ),
 
+    'Converter_ACDC_RECOM_RAC20-xxDK_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_ACDC_RECOM_RAC20-xxDK_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 52.5,  # Package length
+        W  = 27.4,  # Package width
+        H  = 23.0,  # Package height
+        A1 = 0.1,   # Package board separation
+        rim = None, # No rim
+        pin = (('round',  0*p,  0*p, 1.0, 6.0),
+               ('round',  0*p,  8*p, 1.0, 6.0),
+               ('round',  18*p, 0*p, 1.0, 6.0),
+               ('round',  18*p, 4*p, 1.0, 6.0),
+               ('round',  18*p, 8*p, 1.0, 6.0)),  # Pin placement
+        pin1corner = (-3.39, -3.50),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_ACDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TBA1-xxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TBA1-xxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 11.68,   # Package length
+        W  = 6.0,     # Package width
+        H  = 9.65+0.5,# Package height
+        A1 = 0.1,     # Package board separation
+        rim = (0.5, 2.999, 0.5), #nasty bug here if the two rim touches (W=6mm, 2.99+2.99 is ok)
+        pin = (
+               ('rect', 0*p, 0.0, 0.5, 0.25, 3.05),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.05),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 3.05),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.05),
+               ),  # Pin placement
+        pin1corner = (-2.03, 1.35-6.0 ),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TBA1-xxxxE_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TBA1-xxxxE_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.50,  # Package length
+        W  = 6.0,    # Package width
+        H  = 9.5+0.5,# Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 2.999, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.40, -1.35),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TBA1-xxxxHI_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TBA1-xxxxHI_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.50,  # Package length
+        W  = 6.0,    # Package width
+        H  = 9.5+0.5,# Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 2.999, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 6*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.40, -1.35),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TBA2-xxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TBA2-xxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.55,  # Package length
+        W  = 7.6,    # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.45, 3.78, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.40, -1.35),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMA05xxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMA05xxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 6.10,   # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 3.049, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.10, -1.3+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMA12xxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMA12xxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 6.10,   # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 3.049, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.10, -1.3+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMA15xxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMA15xxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 7.10,   # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 3.549, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.10, -1.3+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMA24xxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMA24xxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 7.10,   # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 3.549, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.10, -1.3+0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMAPxxxxx_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMAPxxxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 7.10,   # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 3.549, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.10, -1.8-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMExxxxS_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMExxxxS_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 11.5,    # Package length
+        W  = 6.1,     # Package width
+        H  = 10.2,    # Package height
+        A1 = 0.1,     # Package board separation
+        rim = (0.5, 3.0399, 0.5), #nasty bug here if the two rim touches (W=6mm, 2.99+2.99 is ok)
+        pin = (
+               ('rect', 0*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.2),
+               ),  # Pin placement
+        pin1corner = (-2.03, -4.2-0.25/2  ),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TME24xxS_THT': Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TME24xxS_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 11.5,    # Package length
+        W  = 7.1,     # Package width
+        H  = 10.2,    # Package height
+        A1 = 0.1,     # Package board separation
+        rim = (0.5, 3.54, 0.5),
+        pin = (
+               ('rect', 0*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 2*p, 0.0, 0.5, 0.25, 3.2),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.2),
+               ),  # Pin placement
+        pin1corner = (-2.03, -5.2-0.25/2 ),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+    'Converter_DCDC_TRACO_TMAHxxxxx_THT': Params(   # ModelName
+    'test':Params(   # ModelName
+        #
+        #
+        #
+        modelName = 'Converter_DCDC_TRACO_TMAHxxxxx_THT',  # Model name
+        pintype   = 'tht',  # Pin type, 'tht', 'smd'
+        L  = 19.5,   # Package length
+        W  = 7.50,   # Package width
+        H  = 10.2,   # Package height
+        A1 = 0.1,    # Package board separation
+        rim = (0.5, 3.749, 0.5),
+        pin = (('rect', 0.0, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 1*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 3*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 4*p, 0.0, 0.5, 0.25, 3.0),
+               ('rect', 5*p, 0.0, 0.5, 0.25, 3.0)),  # Pin placement
+        pin1corner = (-2.30, -1.25-0.25/2),  # Left upp corner relationsship to pin 1
+        show_top   = False,  # If top should be visible or not
+        corner     = 'none',  # If top should be cut, 'none', 'chamfer' or 'fillet'
+        roundbelly = 0,  # If belly of caseing should be round (or flat)
+        rotation   = 0,  # If belly of caseing should be round (or flat)
+        body_color_key     = 'black body',  # Body color
+        body_top_color_key = 'black body',  # Body top color
+        pin_color_key      = 'metal grey pins',  # Pin color
+        dest_dir_prefix    = 'Converter_DCDC.3dshapes'  # Destination directory
+        ),
+
+
 }

--- a/cadquery/FCAD_script_generator/Converter_DCDC/launch-cq.sh
+++ b/cadquery/FCAD_script_generator/Converter_DCDC/launch-cq.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Absolute path to this script. /home/user/bin/foo.sh
+SCRIPT=$(readlink -f $0)
+# Absolute path this script is in. /home/user/bin
+SCRIPTPATH=`dirname $SCRIPT`
+echo $SCRIPTPATH
+cd $SCRIPTPATH
+#FreeCAD main_generator.py
+FreeCAD main_generator.py all


### PR DESCRIPTION
Hello Easy

This PR seems big but not really. It merrily makes a single list for the converters and a single main_generator.py
The produced files are still sorted in two directories, no change for that.




They are the same generators but ACDC was not updated same as DCDC
Now a single generator.py to maintain
Single list of converters
And always two DCDC.3dshapes & ACDC.3dshapes output directories.

Note the SMD PAD generator is strange.

I also added a call to rungeometryCheck,
erase the unneeded .FCStd file

I notice ~12 missing converters than probably can be defined here.

Todo: rename this directory to Converters_ACDC_DCDC and erase
Converters_ACDC