### PR TITLE
Changed NXE2 3D model name

### DIFF
--- a/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/Converter_DCDC/cq_parameters.py
@@ -443,11 +443,11 @@ all_params = {
         dest_dir_prefix    = '../Converter_DCDC.3dshapes'  # Destination directory
         ),
 
-    'Converter_DCDC_Murata_NXE2SxxxxMC_THT': Params(   # ModelName
+    'Converter_DCDC_Murata_NXE2SxxxxMC_SMD': Params(   # ModelName
         #
         #
         #
-        modelName = 'Converter_DCDC_Murata_NXE2SxxxxMC_THT',  # Model name
+        modelName = 'Converter_DCDC_Murata_NXE2SxxxxMC_SMD',  # Model name
         pintype   = 'smd',  # Pin type, 'tht', 'smd'
         L  = 10.41,  # Package length
         W  = 12.7,  # Package width


### PR DESCRIPTION
- Renamed the 3D model because it is SMT instead of THT.

[NXE2 Datasheet](https://www.murata.com/products/productdata/8807031898142/kdc-nxe2.pdf#page=9)

This is related to:
[Symbol PR](https://github.com/KiCad/kicad-symbols/pull/2973)
[Footprint PR](https://github.com/KiCad/kicad-footprints/pull/2463)
[3D package PR](https://github.com/KiCad/kicad-packages3D/pull/729)
[3D generator PR](https://github.com/easyw/kicad-3d-models-in-freecad/pull/395)
[Issue](https://github.com/KiCad/kicad-packages3D/issues/727)