### PR TITLE
Add TFBGA-636_19.0x19.0mm_Layout28x28_P0.65mm

### DIFF
--- a/cadquery/FCAD_script_generator/BGA_packages/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/BGA_packages/cq_parameters.py
@@ -1126,6 +1126,26 @@ kicad_naming_params_qfn = {
         rotation = -90, # rotation if required
         dest_dir_prefix = '',
         ),
+    'TFBGA-636_19.0x19.0mm_Layout28x28_P0.65mm': Params( # from
+        fp_r = 0.3,     # first pin indicator radius
+        fp_d = 0.01,    # first pin indicator distance from edge
+        fp_z = 0.01,    # first pin indicator depth
+        ef = 0.0, 		# 0.05,      # fillet of edges  Note: bigger bytes model with fillet
+        D = 19.00,      # body overall length
+        E = 19.00,      # body overall width
+        A1 = 0.15,  	# body-board separation
+        A = 1.10,  		# body  overall height
+        b = 0.40,  		# ball pin width diameter with a small extra to obtain a union of balls and case
+        e = 0.65,  		# pin (center-to-center) distance
+        sp = 0.0, 		# seating plane (pcb penetration)
+        npx = 28,  		# number of pins along X axis (width)
+        npy = 28,  		# number of pins along y axis (length)
+        excluded_pins = ("internals",), #pins to exclude -> None or "internals"
+        old_modelName = 'TFBGA-636_19.0x19.0mm_Layout28x28_P0.65mm', #old_modelName
+        modelName = 'TFBGA-636_19.0x19.0mm_Layout28x28_P0.65mm', #old_modelName
+        rotation = -90, # rotation if required
+        dest_dir_prefix = '',
+        ),
     'FBGA-78_7.5x11mm_Layout2x3x13_P0.8mm': Params( # from https://www.skhynix.com/product/filedata/fileDownload.do?seq=7687
         fp_r = 0.4,     # first pin indicator radius
         fp_d = 0.08,     # first pin indicator distance from edge


### PR DESCRIPTION
Datasheet:
* Realtek RTD1296 https://download.banana-pi.dev/d/3ebbfa04265d4dddb81b/files/?p=%2FDocuments%2FBPI-W2%2F00007316-RTD1296DB_DC_PB_Datasheet_1.6_106005.pdf
* Rockchip RK3288 https://datasheet.lcsc.com/szlcsc/Rockchip-RK3288_C191247.pdf

Screenshot:
![image](https://user-images.githubusercontent.com/3896703/93435518-26863c80-f8fc-11ea-80b4-164d650e713b.png)

Package dimensions from the RTD1296 data sheet on page 7:
![image](https://user-images.githubusercontent.com/3896703/93436006-cba11500-f8fc-11ea-81bb-fb7fdeeb51d9.png)

Package dimensions from the RK3288 data sheet on page 25:
![image](https://user-images.githubusercontent.com/3896703/93436113-eb383d80-f8fc-11ea-90f2-9c843076bf79.png)
