### PR TITLE
Convert THT resistor script

### DIFF
--- a/cadquery/FCAD_script_generator/Resistor_THT/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/Resistor_THT/cq_parameters.py
@@ -1127,9 +1127,9 @@ all_params = {
         shape = 'box',
         orient = 'h'
     ),
-    # doc: http://www.vishay.com/docs/30116/cpcc.pdf
+    # doc: http://www.vishay.com/docs/30218/cpcx.pdf
     'R_Radial_Power_L11.0mm_W7.0mm_P5.00mm': Params(
-        body_color_key = 'light brown body',
+        body_color_key = 'white body',
         pin_color_key = 'metal grey pins',
         l = 11.0,
         d = 22.0, #height
@@ -1141,7 +1141,7 @@ all_params = {
         orient = 'h'
     ),
     'R_Radial_Power_L12.0mm_W8.0mm_P5.00mm': Params(
-        body_color_key = 'light brown body',
+        body_color_key = 'white body',
         pin_color_key = 'metal grey pins',
         l = 12.0,
         d = 24.0, #height
@@ -1153,7 +1153,7 @@ all_params = {
         orient = 'h'
     ),
     'R_Radial_Power_L13.0mm_W9.0mm_P5.00mm': Params(
-        body_color_key = 'light brown body',
+        body_color_key = 'white body',
         pin_color_key = 'metal grey pins',
         l = 13.0,
         d = 26.0, #height
@@ -1165,37 +1165,13 @@ all_params = {
         orient = 'h'
     ),
     'R_Radial_Power_L16.1mm_W9.0mm_P7.37mm': Params(
-        body_color_key = 'light brown body',
+        body_color_key = 'white body',
         pin_color_key = 'metal grey pins',
         l = 16.1,
         d = 32.2, #height
         w = 9.0,
         pd = 0.8,
         px = 7.37,
-        py = 0.0,
-        shape = 'radial',
-        orient = 'h'
-    ),
-    'R_Radial_Power_L16.0mm_W9.0mm_P7.50mm': Params(
-        body_color_key = 'light brown body',
-        pin_color_key = 'metal grey pins',
-        l = 16.0,
-        d = 35.0, #height
-        w = 12.0,
-        pd = 0.8,
-        px = 7.50,
-        py = 0.0,
-        shape = 'radial',
-        orient = 'h'
-    ),
-    'R_Radial_Power_L13.0mm_W10.0mm_P5.00mm': Params(
-        body_color_key = 'light brown body',
-        pin_color_key = 'metal grey pins',
-        l = 13.0,
-        d = 51.0, #height
-        w = 10.0,
-        pd = 0.75,
-        px = 7.50,
         py = 0.0,
         shape = 'radial',
         orient = 'h'
@@ -1236,6 +1212,85 @@ all_params = {
         px = 2.54,
         py = 0.0,
         shape = 'array',
+        orient = 'h'
+    ),
+    # doc: http://www.vishay.com/docs/30116/cpcc.pdf
+    'R_Radial_Power_L11.0mm_W3.5mm_P5.00mm': Params(
+        #cpcpc02
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
+        l = 11.0,
+        d = 20.0, #height
+        w = 3.5,
+        pd = 0.8,
+        px = 5.00,
+        py = 0.0,
+        shape = 'radial',
+        orient = 'h'
+    ),
+    #'R_Radial_Power_L12.0mm_W8.0mm_P5.00mm': Params(
+    #    #cpcc03, equiv cpcx
+    #    body_color_key = 'white body',
+    #    pin_color_key = 'metal grey pins',
+    #    l = 12.0,
+    #    d = 25.0, #height
+    #    w = 8.0,
+    #    pd = 0.8,
+    #    px = 5.00,
+    #    py = 0.0,
+    #    shape = 'radial',
+    #    orient = 'h'
+    #),
+    #'R_Radial_Power_L13.0mm_W9.0mm_P5.00mm': Params(
+    #    #cpcc05, equiv cpcx
+    #    body_color_key = 'white body',
+    #    pin_color_key = 'metal grey pins',
+    #    l = 13.0,
+    #    d = 25.0, #height
+    #    w = 9.0,
+    #    pd = 0.8,
+    #    px = 5.00,
+    #    py = 0.0,
+    #    shape = 'radial',
+    #    orient = 'h'
+    #),
+    'R_Radial_Power_L13.0mm_W9.0mm_P5.0mm': Params(
+        #cpcc07
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
+        l = 13.0,
+        d = 39.0, #height
+        w = 9.0,
+        pd = 0.8,
+        px = 5.0,
+        py = 0.0,
+        shape = 'radial',
+        orient = 'h'
+    ),
+    'R_Radial_Power_L16.0mm_W12.0mm_P7.50mm': Params(
+        #cpcc10
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
+        l = 16.0,
+        d = 35.0, #height
+        w = 12.0,
+        pd = 0.8,
+        px = 7.50,
+        py = 0.0,
+        shape = 'radial',
+        orient = 'h'
+    ),
+    'R_Radial_Power_L13.0mm_W10.0mm_P5.00mm': Params(
+        #cpcc1A
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
+        l = 13.0,
+        d = 51.0, #height
+        w = 10.0,
+        pd = 0.75,
+        px = 5.0,
+        py = 0.0,
+        shape = 'radial',
         orient = 'h'
     ),
 }

--- a/cadquery/FCAD_script_generator/Resistor_THT/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/Resistor_THT/cq_parameters.py
@@ -10,11 +10,26 @@
 # Models are representative
 
 ## file of parametric definitions
+class LICENCE_Info():
+
+    ############################################################################
+    # Licence information of the generated models.
+    #################################################################################################
+    STR_licAuthor = "kicad StepUp"
+    STR_licEmail = "ksu"
+    STR_licOrgSys = "kicad StepUp"
+    STR_licPreProc = "OCC"
+    STR_licOrg = "FreeCAD"
+    LIST_license = ["",]
+
+
 from collections import namedtuple
 
-destination_dir="/Resistors_THT.3dshapes"
+dest_dir_prefix="Resistors_THT.3dshapes"
 
 Params = namedtuple("Params", [
+    'body_color_key',   # Body color
+    'pin_color_key', # pin color
     'l',      # length of body (x for horiz, z for vert)
     'd',      # diameter/depth of body (z for h, x for vert)
     'w',      # width of body (typically y)
@@ -27,8 +42,10 @@ Params = namedtuple("Params", [
 
 # entries checked against datasheet have a comment with the datasheet link
 
-kicad_naming_params_resistors_tht = {
-    'R_Axial_DIN0204_L3.6mm_D1.6mm_P1.90mm_Vertical': Params(	
+all_params = {
+    'R_Axial_DIN0204_L3.6mm_D1.6mm_P1.90mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 3.6,
         d = 1.6,
         w = 0.0,
@@ -38,7 +55,9 @@ kicad_naming_params_resistors_tht = {
         shape = 'din',
         orient = 'v'
     ),
-    'R_Axial_DIN0204_L3.6mm_D1.6mm_P2.54mm_Vertical': Params(	
+    'R_Axial_DIN0204_L3.6mm_D1.6mm_P2.54mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 3.6,
         d = 1.6,
         w = 0.0,
@@ -48,7 +67,9 @@ kicad_naming_params_resistors_tht = {
         shape = 'din',
         orient = 'v'
     ),
-    'R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal': Params(	
+    'R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 3.6,
         d = 1.6,
         w = 0.0,
@@ -57,8 +78,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),    
+    ),
     'R_Axial_DIN0204_L3.6mm_D1.6mm_P5.08mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 3.6,
         d = 1.6,
         w = 0.0,
@@ -69,6 +92,8 @@ kicad_naming_params_resistors_tht = {
         orient = 'v'
     ),
     'R_Axial_DIN0204_L3.6mm_D1.6mm_P7.62mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 3.6,
         d = 1.6,
         w = 0.0,
@@ -78,7 +103,9 @@ kicad_naming_params_resistors_tht = {
         shape = 'din',
         orient = 'h'
     ),
-    'R_Axial_DIN0207_L6.3mm_D2.5mm_P10.16mm_Horizontal': Params(	
+    'R_Axial_DIN0207_L6.3mm_D2.5mm_P10.16mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 6.3,
         d = 2.5,
         w = 0.0,
@@ -88,7 +115,9 @@ kicad_naming_params_resistors_tht = {
         shape = 'din',
         orient = 'h'
     ),
-    'R_Axial_DIN0207_L6.3mm_D2.5mm_P15.24mm_Horizontal': Params(	
+    'R_Axial_DIN0207_L6.3mm_D2.5mm_P15.24mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 6.3,
         d = 2.5,
         w = 0.0,
@@ -98,7 +127,9 @@ kicad_naming_params_resistors_tht = {
         shape = 'din',
         orient = 'h'
     ),
-    'R_Axial_DIN0207_L6.3mm_D2.5mm_P2.54mm_Vertical': Params(	
+    'R_Axial_DIN0207_L6.3mm_D2.5mm_P2.54mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 6.3,
         d = 2.5,
         w = 0.0,
@@ -108,7 +139,9 @@ kicad_naming_params_resistors_tht = {
         shape = 'din',
         orient = 'v'
     ),
-    'R_Axial_DIN0207_L6.3mm_D2.5mm_P5.08mm_Vertical': Params(	
+    'R_Axial_DIN0207_L6.3mm_D2.5mm_P5.08mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 6.3,
         d = 2.5,
         w = 0.0,
@@ -118,7 +151,9 @@ kicad_naming_params_resistors_tht = {
         shape = 'din',
         orient = 'v'
     ),
-    'R_Axial_DIN0207_L6.3mm_D2.5mm_P7.62mm_Horizontal': Params(	
+    'R_Axial_DIN0207_L6.3mm_D2.5mm_P7.62mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 6.3,
         d = 2.5,
         w = 0.0,
@@ -127,8 +162,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),  
-    'R_Axial_DIN0309_L9.0mm_D3.2mm_P12.70mm_Horizontal': Params(	
+    ),
+    'R_Axial_DIN0309_L9.0mm_D3.2mm_P12.70mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 9.0,
         d = 3.2,
         w = 0.0,
@@ -137,8 +174,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),  
-    'R_Axial_DIN0309_L9.0mm_D3.2mm_P15.24mm_Horizontal': Params(	
+    ),
+    'R_Axial_DIN0309_L9.0mm_D3.2mm_P15.24mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 9.0,
         d = 3.2,
         w = 0.0,
@@ -147,8 +186,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),      
-    'R_Axial_DIN0309_L9.0mm_D3.2mm_P2.54mm_Vertical': Params(	
+    ),
+    'R_Axial_DIN0309_L9.0mm_D3.2mm_P2.54mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 9.0,
         d = 3.2,
         w = 0.0,
@@ -157,8 +198,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'v'
-    ),  
-    'R_Axial_DIN0309_L9.0mm_D3.2mm_P20.32mm_Horizontal': Params(	
+    ),
+    'R_Axial_DIN0309_L9.0mm_D3.2mm_P20.32mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 9.0,
         d = 3.2,
         w = 0.0,
@@ -167,8 +210,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),  
-    'R_Axial_DIN0309_L9.0mm_D3.2mm_P25.40mm_Horizontal': Params(	
+    ),
+    'R_Axial_DIN0309_L9.0mm_D3.2mm_P25.40mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 9.0,
         d = 3.2,
         w = 0.0,
@@ -177,8 +222,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),  
-    'R_Axial_DIN0309_L9.0mm_D3.2mm_P5.08mm_Horizontal': Params(	
+    ),
+    'R_Axial_DIN0309_L9.0mm_D3.2mm_P5.08mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 9.0,
         d = 3.2,
         w = 0.0,
@@ -189,6 +236,8 @@ kicad_naming_params_resistors_tht = {
         orient = 'v'
     ),
     'R_Axial_DIN0309_L9.0mm_D3.2mm_P5.08mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 9.0,
         d = 3.2,
         w = 0.0,
@@ -199,6 +248,8 @@ kicad_naming_params_resistors_tht = {
         orient = 'v'
     ),
     'R_Axial_DIN0411_L9.9mm_D3.6mm_P5.08mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 9.9,
         d = 3.6,
         w = 0.0,
@@ -209,6 +260,8 @@ kicad_naming_params_resistors_tht = {
         orient = 'v'
     ),
     'R_Axial_DIN0411_L9.9mm_D3.6mm_P12.70mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 9.9,
         d = 3.6,
         w = 0.0,
@@ -219,6 +272,8 @@ kicad_naming_params_resistors_tht = {
         orient = 'h'
     ),
     'R_Axial_DIN0411_L9.9mm_D3.6mm_P15.24mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 9.9,
         d = 3.6,
         w = 0.0,
@@ -229,6 +284,8 @@ kicad_naming_params_resistors_tht = {
         orient = 'h'
     ),
     'R_Axial_DIN0411_L9.9mm_D3.6mm_P20.32mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 9.9,
         d = 3.6,
         w = 0.0,
@@ -239,6 +296,8 @@ kicad_naming_params_resistors_tht = {
         orient = 'h'
     ),
     'R_Axial_DIN0411_L9.9mm_D3.6mm_P25.40mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 9.9,
         d = 3.6,
         w = 0.0,
@@ -249,6 +308,8 @@ kicad_naming_params_resistors_tht = {
         orient = 'h'
     ),
     'R_Axial_DIN0411_L9.9mm_D3.6mm_P5.08mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 9.9,
         d = 3.6,
         w = 0.0,
@@ -259,6 +320,8 @@ kicad_naming_params_resistors_tht = {
         orient = 'v'
     ),
     'R_Axial_DIN0411_L9.9mm_D3.6mm_P7.62mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 9.9,
         d = 3.6,
         w = 0.0,
@@ -269,6 +332,8 @@ kicad_naming_params_resistors_tht = {
         orient = 'v'
     ),
     'R_Axial_DIN0414_L11.9mm_D4.5mm_P15.24mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 11.9,
         d = 4.5,
         w = 0.0,
@@ -277,8 +342,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),    
+    ),
     'R_Axial_DIN0414_L11.9mm_D4.5mm_P20.32mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 11.9,
         d = 4.5,
         w = 0.0,
@@ -287,8 +354,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),    
+    ),
     'R_Axial_DIN0414_L11.9mm_D4.5mm_P25.40mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 11.9,
         d = 4.5,
         w = 0.0,
@@ -297,8 +366,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),    
+    ),
     'R_Axial_DIN0414_L11.9mm_D4.5mm_P5.08mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 11.9,
         d = 4.5,
         w = 0.0,
@@ -309,6 +380,8 @@ kicad_naming_params_resistors_tht = {
         orient = 'v'
     ),
     'R_Axial_DIN0414_L11.9mm_D4.5mm_P7.62mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 11.9,
         d = 4.5,
         w = 0.0,
@@ -317,8 +390,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'v'
-    ),  
+    ),
     'R_Axial_DIN0516_L15.5mm_D5.0mm_P20.32mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 15.5,
         d = 5.0,
         w = 0.0,
@@ -329,6 +404,8 @@ kicad_naming_params_resistors_tht = {
         orient = 'h'
     ),
     'R_Axial_DIN0516_L15.5mm_D5.0mm_P25.40mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 15.5,
         d = 5.0,
         w = 0.0,
@@ -339,6 +416,8 @@ kicad_naming_params_resistors_tht = {
         orient = 'h'
     ),
     'R_Axial_DIN0516_L15.5mm_D5.0mm_P30.48mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 15.5,
         d = 5.0,
         w = 0.0,
@@ -347,8 +426,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),    
+    ),
     'R_Axial_DIN0516_L15.5mm_D5.0mm_P5.08mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 15.5,
         d = 5.0,
         w = 0.0,
@@ -357,8 +438,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'v'
-    ),      
+    ),
     'R_Axial_DIN0516_L15.5mm_D5.0mm_P7.62mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 15.5,
         d = 5.0,
         w = 0.0,
@@ -367,8 +450,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'v'
-    ),       
+    ),
     'R_Axial_DIN0614_L14.3mm_D5.7mm_P15.24mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 14.3,
         d = 5.7,
         w = 0.0,
@@ -377,8 +462,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),     
+    ),
     'R_Axial_DIN0614_L14.3mm_D5.7mm_P20.32mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 14.3,
         d = 5.7,
         w = 0.0,
@@ -387,8 +474,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),         
+    ),
     'R_Axial_DIN0614_L14.3mm_D5.7mm_P25.40mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 14.3,
         d = 5.7,
         w = 0.0,
@@ -397,8 +486,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),         
+    ),
     'R_Axial_DIN0614_L14.3mm_D5.7mm_P5.08mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 14.3,
         d = 5.7,
         w = 0.0,
@@ -407,8 +498,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'v'
-    ),         
+    ),
     'R_Axial_DIN0614_L14.3mm_D5.7mm_P7.62mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 14.3,
         d = 5.7,
         w = 0.0,
@@ -417,8 +510,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'v'
-    ),  
+    ),
     'R_Axial_DIN0617_L17.0mm_D6.0mm_P20.32mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 17.0,
         d = 6.0,
         w = 0.0,
@@ -427,8 +522,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),      
+    ),
     'R_Axial_DIN0617_L17.0mm_D6.0mm_P25.40mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 17.0,
         d = 6.0,
         w = 0.0,
@@ -437,8 +534,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),    
+    ),
     'R_Axial_DIN0617_L17.0mm_D6.0mm_P30.48mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 17.0,
         d = 6.0,
         w = 0.0,
@@ -447,8 +546,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),    
+    ),
     'R_Axial_DIN0617_L17.0mm_D6.0mm_P5.08mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 17.0,
         d = 6.0,
         w = 0.0,
@@ -457,8 +558,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'v'
-    ),        
+    ),
     'R_Axial_DIN0617_L17.0mm_D6.0mm_P7.62mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 17.0,
         d = 6.0,
         w = 0.0,
@@ -467,8 +570,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'v'
-    ),      
+    ),
     'R_Axial_DIN0918_L18.0mm_D9.0mm_P22.86mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 18.0,
         d = 9.0,
         w = 0.0,
@@ -477,8 +582,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),   
+    ),
     'R_Axial_DIN0918_L18.0mm_D9.0mm_P25.40mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 18.0,
         d = 9.0,
         w = 0.0,
@@ -487,8 +594,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),  
+    ),
     'R_Axial_DIN0918_L18.0mm_D9.0mm_P30.48mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 18.0,
         d = 9.0,
         w = 0.0,
@@ -497,8 +606,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'h'
-    ),  
+    ),
     'R_Axial_DIN0918_L18.0mm_D9.0mm_P7.62mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 18.0,
         d = 9.0,
         w = 0.0,
@@ -507,8 +618,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'v'
-    ),  
+    ),
     'R_Axial_DIN0922_L20.0mm_D9.0mm_P25.40mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 20.0,
         d = 9.0,
         w = 0.0,
@@ -519,6 +632,8 @@ kicad_naming_params_resistors_tht = {
         orient = 'h'
     ),
     'R_Axial_DIN0922_L20.0mm_D9.0mm_P30.48mm_Horizontal': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 20.0,
         d = 9.0,
         w = 0.0,
@@ -529,6 +644,8 @@ kicad_naming_params_resistors_tht = {
         orient = 'h'
     ),
     'R_Axial_DIN0922_L20.0mm_D9.0mm_P7.62mm_Vertical': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 20.0,
         d = 9.0,
         w = 0.0,
@@ -537,8 +654,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'din',
         orient = 'v'
-    ),    
-    'R_Axial_Power_L20.0mm_W6.4mm_P22.40mm': Params(	
+    ),
+    'R_Axial_Power_L20.0mm_W6.4mm_P22.40mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 20.0,
         d = 6.4,
         w = 6.4,
@@ -548,7 +667,9 @@ kicad_naming_params_resistors_tht = {
         shape = 'power',
         orient = 'h'
     ),
-    'R_Axial_Power_L20.0mm_W6.4mm_P25.40mm': Params(	
+    'R_Axial_Power_L20.0mm_W6.4mm_P25.40mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 20.0,
         d = 6.4,
         w = 6.4,
@@ -558,7 +679,9 @@ kicad_naming_params_resistors_tht = {
         shape = 'power',
         orient = 'h'
     ),
-    'R_Axial_Power_L20.0mm_W6.4mm_P30.48mm': Params(	
+    'R_Axial_Power_L20.0mm_W6.4mm_P30.48mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 20.0,
         d = 6.4,
         w = 6.4,
@@ -568,7 +691,9 @@ kicad_naming_params_resistors_tht = {
         shape = 'power',
         orient = 'h'
     ),
-    'R_Axial_Power_L20.0mm_W6.4mm_P5.08mm_Vertical': Params(	
+    'R_Axial_Power_L20.0mm_W6.4mm_P5.08mm_Vertical': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 20.0,
         d = 6.4,
         w = 6.4,
@@ -577,8 +702,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'power',
         orient = 'v'
-    ),    
-    'R_Axial_Power_L20.0mm_W6.4mm_P7.62mm_Vertical': Params(	
+    ),
+    'R_Axial_Power_L20.0mm_W6.4mm_P7.62mm_Vertical': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 20.0,
         d = 6.4,
         w = 6.4,
@@ -587,8 +714,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'power',
         orient = 'v'
-    ),        
-    'R_Axial_Power_L25.0mm_W6.4mm_P27.94mm': Params(	
+    ),
+    'R_Axial_Power_L25.0mm_W6.4mm_P27.94mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 25.0,
         d = 6.4,
         w = 6.4,
@@ -597,8 +726,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'power',
         orient = 'h'
-    ),    
-    'R_Axial_Power_L25.0mm_W6.4mm_P30.48mm': Params(	
+    ),
+    'R_Axial_Power_L25.0mm_W6.4mm_P30.48mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 25.0,
         d = 6.4,
         w = 6.4,
@@ -607,8 +738,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'power',
         orient = 'h'
-    ),     
-    'R_Axial_Power_L25.0mm_W9.0mm_P10.16mm_Vertical': Params(	
+    ),
+    'R_Axial_Power_L25.0mm_W9.0mm_P10.16mm_Vertical': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 25.0,
         d = 9.0,
         w = 9.0,
@@ -617,8 +750,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'power',
         orient = 'v'
-    ),     
-    'R_Axial_Power_L25.0mm_W9.0mm_P27.94mm': Params(	
+    ),
+    'R_Axial_Power_L25.0mm_W9.0mm_P27.94mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 25.0,
         d = 9.0,
         w = 9.0,
@@ -627,8 +762,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'power',
         orient = 'h'
-    ),   
-    'R_Axial_Power_L25.0mm_W9.0mm_P30.48mm': Params(	
+    ),
+    'R_Axial_Power_L25.0mm_W9.0mm_P30.48mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 25.0,
         d = 9.0,
         w = 9.0,
@@ -637,8 +774,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'power',
         orient = 'h'
-    ), 
-    'R_Axial_Power_L25.0mm_W9.0mm_P7.62mm_Vertical': Params(	
+    ),
+    'R_Axial_Power_L25.0mm_W9.0mm_P7.62mm_Vertical': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 25.0,
         d = 9.0,
         w = 9.0,
@@ -648,7 +787,9 @@ kicad_naming_params_resistors_tht = {
         shape = 'power',
         orient = 'v'
     ),
-    'R_Axial_Power_L38.0mm_W6.4mm_P40.64mm': Params(	
+    'R_Axial_Power_L38.0mm_W6.4mm_P40.64mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 38.0,
         d = 6.4,
         w = 6.4,
@@ -657,8 +798,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'power',
         orient = 'h'
-    ),  
-    'R_Axial_Power_L38.0mm_W6.4mm_P45.72mm': Params(	
+    ),
+    'R_Axial_Power_L38.0mm_W6.4mm_P45.72mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 38.0,
         d = 6.4,
         w = 6.4,
@@ -667,8 +810,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'power',
         orient = 'h'
-    ),    
-    'R_Axial_Power_L38.0mm_W9.0mm_P40.64mm': Params(	
+    ),
+    'R_Axial_Power_L38.0mm_W9.0mm_P40.64mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 38.0,
         d = 9.0,
         w = 9.0,
@@ -677,8 +822,10 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'power',
         orient = 'h'
-    ),    
-    'R_Axial_Power_L38.0mm_W9.0mm_P45.72mm': Params(	
+    ),
+    'R_Axial_Power_L38.0mm_W9.0mm_P45.72mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 38.0,
         d = 9.0,
         w = 9.0,
@@ -688,7 +835,9 @@ kicad_naming_params_resistors_tht = {
         shape = 'power',
         orient = 'h'
     ),
-    'R_Axial_Power_L48.0mm_W12.5mm_P10.16mm_Vertical': Params(	
+    'R_Axial_Power_L48.0mm_W12.5mm_P10.16mm_Vertical': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 48.0,
         d = 12.5,
         w = 12.5,
@@ -697,28 +846,34 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'power',
         orient = 'v'
-    ),        
-    'R_Axial_Power_L48.0mm_W12.5mm_P55.88mm': Params(	
+    ),
+    'R_Axial_Power_L48.0mm_W12.5mm_P55.88mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 48.0,
         d = 12.5,
-        w = 12.5, 
+        w = 12.5,
         pd = 0.8,
         px = 55.88,
         py = 0.0,
         shape = 'power',
         orient = 'h'
-    ),         
-    'R_Axial_Power_L48.0mm_W12.5mm_P60.96mm': Params(	
+    ),
+    'R_Axial_Power_L48.0mm_W12.5mm_P60.96mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 48.0,
         d = 12.5,
-        w = 12.5, 
+        w = 12.5,
         pd = 0.8,
         px = 60.96,
         py = 0.0,
         shape = 'power',
         orient = 'h'
-    ),      
-    'R_Axial_Power_L48.0mm_W12.5mm_P7.62mm_Vertical': Params(	
+    ),
+    'R_Axial_Power_L48.0mm_W12.5mm_P7.62mm_Vertical': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 48.0,
         d = 12.5,
         w = 12.5,
@@ -727,28 +882,34 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'power',
         orient = 'v'
-    ),     
-    'R_Axial_Power_L50.0mm_W9.0mm_P55.88mm': Params(	
+    ),
+    'R_Axial_Power_L50.0mm_W9.0mm_P55.88mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 50.0,
         d = 9.0,
-        w = 9.0, 
+        w = 9.0,
         pd = 0.8,
         px = 55.88,
         py = 0.0,
         shape = 'power',
         orient = 'h'
-    ),     
-    'R_Axial_Power_L50.0mm_W9.0mm_P60.96mm': Params(	
+    ),
+    'R_Axial_Power_L50.0mm_W9.0mm_P60.96mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 50.0,
         d = 9.0,
-        w = 9.0, 
+        w = 9.0,
         pd = 0.8,
         px = 60.96,
         py = 0.0,
         shape = 'power',
         orient = 'h'
-    ),     
-    'R_Axial_Power_L60.0mm_W14.0mm_P10.16mm_Vertical': Params(	
+    ),
+    'R_Axial_Power_L60.0mm_W14.0mm_P10.16mm_Vertical': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 60.0,
         d = 14.0,
         w = 14.0,
@@ -757,251 +918,320 @@ kicad_naming_params_resistors_tht = {
         py = 0.0,
         shape = 'power',
         orient = 'v'
-    ),    
-    'R_Axial_Power_L60.0mm_W14.0mm_P66.04mm': Params(	
+    ),
+    'R_Axial_Power_L60.0mm_W14.0mm_P66.04mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 60.0,
         d = 14.0,
-        w = 14.0, 
+        w = 14.0,
         pd = 0.8,
         px = 66.04,
         py = 0.0,
         shape = 'power',
         orient = 'h'
-    ), 
-    'R_Axial_Power_L60.0mm_W14.0mm_P71.12mm': Params(	
+    ),
+    'R_Axial_Power_L60.0mm_W14.0mm_P71.12mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 60.0,
         d = 14.0,
-        w = 14.0, 
+        w = 14.0,
         pd = 0.8,
         px = 71.12,
         py = 0.0,
         shape = 'power',
         orient = 'h'
-    ), 
-    'R_Axial_Power_L75.0mm_W9.0mm_P81.28mm': Params(	
+    ),
+    'R_Axial_Power_L75.0mm_W9.0mm_P81.28mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 75.0,
         d = 9.0,
-        w = 9.0, 
+        w = 9.0,
         pd = 0.8,
         px = 81.28,
         py = 0.0,
         shape = 'power',
         orient = 'h'
-    ),   
-    'R_Axial_Power_L75.0mm_W9.0mm_P86.36mm': Params(	
+    ),
+    'R_Axial_Power_L75.0mm_W9.0mm_P86.36mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 75.0,
         d = 9.0,
-        w = 9.0, 
+        w = 9.0,
         pd = 0.8,
         px = 86.36,
         py = 0.0,
         shape = 'power',
         orient = 'h'
     ),
-    'R_Axial_Shunt_L22.2mm_W8.0mm_PS14.30mm_P25.40mm': Params(	
-        # doc: http://www.vishay.com/docs/30217/cpsl.pdf
+    # doc: http://www.vishay.com/docs/30217/cpsl.pdf
+    'R_Axial_Shunt_L22.2mm_W8.0mm_PS14.30mm_P25.40mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 22.2,
         d = 8.0, # height
-        w = 8.0, 
+        w = 8.0,
         pd = 0.914,
         px = 25.40,
         py = 14.30,
         shape = 'shunt',
         orient = 'h'
     ),
-    'R_Axial_Shunt_L22.2mm_W9.5mm_PS14.30mm_P25.40mm': Params(	
-        # doc: http://www.vishay.com/docs/30217/cpsl.pdf
+    'R_Axial_Shunt_L22.2mm_W9.5mm_PS14.30mm_P25.40mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 22.2,
         d = 8.73, # height
-        w = 9.5, 
+        w = 9.5,
         pd = 0.914,
         px = 25.40,
         py = 14.30,
         shape = 'shunt',
         orient = 'h'
     ),
-    'R_Axial_Shunt_L35.3mm_W9.5mm_PS25.40mm_P38.10mm': Params(	
-        # doc: http://www.vishay.com/docs/30217/cpsl.pdf
+    'R_Axial_Shunt_L35.3mm_W9.5mm_PS25.40mm_P38.10mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 35.3,
         d = 8.73, # height
-        w = 9.5, 
+        w = 9.5,
         pd = 0.914,
         px = 38.10,
         py = 25.40,
         shape = 'shunt',
         orient = 'h'
     ),
-    'R_Axial_Shunt_L47.6mm_W12.7mm_PS34.93mm_P50.80mm': Params(	
-        # doc: http://www.vishay.com/docs/30217/cpsl.pdf
+    'R_Axial_Shunt_L47.6mm_W12.7mm_PS34.93mm_P50.80mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 47.6,
         d = 12.7,
-        w = 12.7, 
+        w = 12.7,
         pd = 0.914,
         px = 50.80,
         py = 34.93,
         shape = 'shunt',
         orient = 'h'
     ),
-    'R_Axial_Shunt_L47.6mm_W9.5mm_PS34.93mm_P50.80mm': Params(	
-        # doc: http://www.vishay.com/docs/30217/cpsl.pdf
+    'R_Axial_Shunt_L47.6mm_W9.5mm_PS34.93mm_P50.80mm': Params(
+        body_color_key = 'white body',
+        pin_color_key = 'metal grey pins',
         l = 47.6,
         d = 8.73, # height
-        w = 9.5, 
+        w = 9.5,
         pd = 0.8,
         px = 50.80,
         py = 34.93,
         shape = 'shunt',
         orient = 'h'
     ),
-    'R_Bare_Metal_Element_L12.4mm_W4.8mm_P11.40mm': Params(	
-        # doc: http://www.arcolresistors.com/wp-content/uploads/2011/07/MSR-6-11.272.pdf
+    # doc: http://www.arcolresistors.com/wp-content/uploads/2011/07/MSR-6-11.272.pdf
+    'R_Bare_Metal_Element_L12.4mm_W4.8mm_P11.40mm': Params(
+        body_color_key = 'metal grey pins',
+        pin_color_key = 'metal grey pins',
         l = 12.4,
         d = 5.10, #height
-        w = 4.8, 
+        w = 4.8,
         pd = 1.7,
         px = 11.40,
         py = 0.0,
         shape = 'bare',
         orient = 'h'
     ),
-    'R_Bare_Metal_Element_L16.3mm_W4.8mm_P15.30mm': Params(	
+    'R_Bare_Metal_Element_L16.3mm_W4.8mm_P15.30mm': Params(
+        body_color_key = 'metal grey pins',
+        pin_color_key = 'metal grey pins',
         l = 16.3,
         d = 25.4, #height
-        w = 4.8, 
+        w = 4.8,
         pd = 1.7,
         px = 15.30,
         py = 0.0,
         shape = 'bare',
         orient = 'h'
-    ),    
-    'R_Bare_Metal_Element_L21.3mm_W4.8mm_P20.30mm': Params(	
+    ),
+    'R_Bare_Metal_Element_L21.3mm_W4.8mm_P20.30mm': Params(
+        body_color_key = 'metal grey pins',
+        pin_color_key = 'metal grey pins',
         l = 21.3,
         d = 25.4, #height
-        w = 4.8, 
+        w = 4.8,
         pd = 1.7,
         px = 20.30,
         py = 0.0,
         shape = 'bare',
         orient = 'h'
-    ), 
-    'R_Box_L13.0mm_W4.0mm_P9.00mm': Params(	
+    ),
+    'R_Box_L13.0mm_W4.0mm_P9.00mm': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 13.0,
         d = 8.0, #height
-        w = 4.0, 
+        w = 4.0,
         pd = 0.8,
         px = 9.00,
         py = 0.0,
         shape = 'box',
         orient = 'h'
     ),
-    'R_Box_L13.0mm_W4.0mm_P9.00mm': Params(	
+    'R_Box_L13.0mm_W4.0mm_P9.00mm': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 13.0,
         d = 8.0, #height
-        w = 4.0, 
+        w = 4.0,
         pd = 0.8,
         px = 9.00,
         py = 0.0,
         shape = 'box',
         orient = 'h'
-    ),  
-    'R_Box_L14.0mm_W5.0mm_P9.00mm': Params(	
+    ),
+    'R_Box_L14.0mm_W5.0mm_P9.00mm': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 14.0,
         d = 10.0, #height
-        w = 5.0, 
+        w = 5.0,
         pd = 0.8,
         px = 9.00,
         py = 0.0,
         shape = 'box',
         orient = 'h'
-    ), 
-    'R_Box_L26.0mm_W5.0mm_P20.00mm': Params(	
-        # doc: http://www.produktinfo.conrad.com/datenblaetter/425000-449999/443860-da-01-de-METALLBAND_WIDERSTAND_0_1_OHM_5W_5Pr.pdf
+    ),
+    # doc: http://www.produktinfo.conrad.com/datenblaetter/425000-449999/443860-da-01-de-METALLBAND_WIDERSTAND_0_1_OHM_5W_5Pr.pdf
+    'R_Box_L26.0mm_W5.0mm_P20.00mm': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 26.0,
         d = 18.0,
-        w = 5.0, 
+        w = 5.0,
         pd = 0.8,
         px = 20.00,
         py = 0.0,
         shape = 'box',
         orient = 'h'
-    ), 
-    'R_Box_L8.4mm_W2.5mm_P5.08mm': Params(	
-        # doc: http://www.vishay.com/docs/60051/cns020.pdf
+    ),
+    # doc: http://www.vishay.com/docs/60051/cns020.pdf
+    'R_Box_L8.4mm_W2.5mm_P5.08mm': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 8.4,
         d = 6.7, #height
-        w = 2.5, 
+        w = 2.5,
         pd = 0.6,
         px = 5.08,
         py = 0.0,
         shape = 'box',
         orient = 'h'
-    ),     
-    'R_Radial_Power_L11.0mm_W7.0mm_P5.00mm': Params(	
+    ),
+    # doc: http://www.vishay.com/docs/30116/cpcc.pdf
+    'R_Radial_Power_L11.0mm_W7.0mm_P5.00mm': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 11.0,
         d = 22.0, #height
-        w = 7.0, 
-        pd = 0.8,
-        px = 5.00,
-        py = 0.0,
-        shape = 'radial',
-        orient = 'h'
-    ), 
-    'R_Radial_Power_L12.0mm_W8.0mm_P5.00mm': Params(	
-        l = 12.0,
-        d = 24.0, #height
-        w = 8.0, 
+        w = 7.0,
         pd = 0.8,
         px = 5.00,
         py = 0.0,
         shape = 'radial',
         orient = 'h'
     ),
-    'R_Radial_Power_L13.0mm_W9.0mm_P5.00mm': Params(	
-        l = 13.0,
-        d = 26.0, #height
-        w = 9.0, 
+    'R_Radial_Power_L12.0mm_W8.0mm_P5.00mm': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
+        l = 12.0,
+        d = 24.0, #height
+        w = 8.0,
         pd = 0.8,
         px = 5.00,
         py = 0.0,
         shape = 'radial',
         orient = 'h'
-    ),    
-    'R_Radial_Power_L16.1mm_W9.0mm_P7.37mm': Params(	
+    ),
+    'R_Radial_Power_L13.0mm_W9.0mm_P5.00mm': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
+        l = 13.0,
+        d = 26.0, #height
+        w = 9.0,
+        pd = 0.8,
+        px = 5.00,
+        py = 0.0,
+        shape = 'radial',
+        orient = 'h'
+    ),
+    'R_Radial_Power_L16.1mm_W9.0mm_P7.37mm': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 16.1,
         d = 32.2, #height
-        w = 9.0, 
+        w = 9.0,
         pd = 0.8,
         px = 7.37,
         py = 0.0,
         shape = 'radial',
         orient = 'h'
     ),
-    'R_Radial_Power_L7.0mm_W8.0mm_Px2.40mm_Py2.30mm': Params(	
-        # doc: http://www.vitrohm.com/content/files/vitrohm_series_kvs_-_201702.pdf
+    'R_Radial_Power_L16.0mm_W9.0mm_P7.50mm': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
+        l = 16.0,
+        d = 35.0, #height
+        w = 12.0,
+        pd = 0.8,
+        px = 7.50,
+        py = 0.0,
+        shape = 'radial',
+        orient = 'h'
+    ),
+    'R_Radial_Power_L13.0mm_W10.0mm_P5.00mm': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
+        l = 13.0,
+        d = 51.0, #height
+        w = 10.0,
+        pd = 0.75,
+        px = 7.50,
+        py = 0.0,
+        shape = 'radial',
+        orient = 'h'
+    ),
+    # doc: http://www.vitrohm.com/content/files/vitrohm_series_kvs_-_201702.pdf
+    'R_Radial_Power_L7.0mm_W8.0mm_Px2.40mm_Py2.30mm': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 7.0,
         d = 38.0, #height
-        w = 8.0, 
+        w = 8.0,
         pd = 1.0,
         px = 2.40,
         py = 2.30,
         shape = 'radial',
         orient = 'h'
     ),
-    'R_Radial_Power_L9.0mm_W10.0mm_Px2.70mm_Py2.30mm': Params(	
-        # doc: http://www.vitrohm.com/content/files/vitrohm_series_kvs_-_201702.pdf
+    'R_Radial_Power_L9.0mm_W10.0mm_Px2.70mm_Py2.30mm': Params(
+        body_color_key = 'light brown body',
+        pin_color_key = 'metal grey pins',
         l = 9.0,
         d = 75.0, #height
-        w = 10.0, 
+        w = 10.0,
         pd = 1.0,
         px = 2.70,
         py = 2.30,
         shape = 'radial',
         orient = 'h'
     ),
-    'R_Array_SIP': Params(	# https://www.vishay.com/docs/31509/csc.pdf
+    # https://www.vishay.com/docs/31509/csc.pdf
+    'R_Array_SIP': Params(
+        body_color_key = 'red body',
+        pin_color_key = 'metal grey pins',
         l = 0.0,
         d = 5.0, #height
-        w = 2.5, 
+        w = 2.5,
         pd = 0.5,
         px = 2.54,
         py = 0.0,

--- a/cadquery/FCAD_script_generator/Resistor_THT/create_model.sh
+++ b/cadquery/FCAD_script_generator/Resistor_THT/create_model.sh
@@ -6,6 +6,6 @@ SCRIPT=$(readlink -f $0)
 SCRIPTPATH=`dirname $SCRIPT`
 echo $SCRIPTPATH
 cd $SCRIPTPATH
-echo Best using FC 0.15
+echo Best using FC 0.18
 #freecad  main_generator.py  R_Axial_Power_L60.0mm_W14.0mm_P66.04mm
-freecad  main_generator.py $1
+FreeCAD  main_generator.py all

--- a/cadquery/FCAD_script_generator/Resistor_THT/create_model.sh
+++ b/cadquery/FCAD_script_generator/Resistor_THT/create_model.sh
@@ -8,4 +8,4 @@ echo $SCRIPTPATH
 cd $SCRIPTPATH
 echo Best using FC 0.18
 #freecad  main_generator.py  R_Axial_Power_L60.0mm_W14.0mm_P66.04mm
-FreeCAD  main_generator.py all
+FreeCAD  main_generator.py $1


### PR DESCRIPTION
to run python3
to adopt recent change (same script as Converter DCDC)

cq_parameters:

moved the color info in each variant
changed color of SIP resistor to Red
added two sizes for the power vishay CPCC serie: CPC10 CPCC1A
Can't tell if previous CPCC10 was an error (pitch=7.37 ??) it is no more
in the PDF

Remove lot of eol spaces character

Suggestion: use green body for power round resistor, Sfernice like.

adding vishay CPCC  CPC10 CPCC1A 3dimages was the primary goal