### PR TITLE
Added  script files for generating 3D models of tactile buttons

### DIFF
--- a/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/README.md
+++ b/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/README.md
@@ -1,0 +1,90 @@
+Following SMD models can be generated:    
+(Click entry to unfold/fold)  
+<details>  
+  <summary>SMD tactile buttons</summary>  
+
+- SW_SPST_B3S-1000      
+- SW_SPST_B3S-1100      
+- SW_SPST_B3SL-1002P      
+- SW_SPST_B3SL-1022P      
+- SW_SPST_B3U-1100P-B      
+- SW_SPST_B3U-1100P      
+- SW_SPST_Omron_B3FS-100xP      
+- SW_SPST_Omron_B3FS-101xP      
+- SW_SPST_Omron_B3FS-105xP      
+- SW_push_1P1T_NO_CK_KSC6xxJxxx      
+- SW_push_1P1T_NO_CK_KSC7xxJxxx      
+- SW_SPST_EVPBF
+- SW_SPST_EVQP0
+- SW_SPST_EVQP2
+- SW_SPST_Panasonic_EVQPL_3PL_5PL_PT_A08
+- SW_SPST_Panasonic_EVQPL_3PL_5PL_PT_A15
+- SW_PUSH_6mm_H9.5mm
+- SW_SPST_SKQG_WithStem
+- SW_SPST_SKQG_WithoutStem
+- SW_SPST_TL3305A
+- SW_SPST_TL3305B
+- SW_SPST_TL3305C
+- SW_Push_SPST_NO_Alps_SKRK
+- SW_Push_1P1T_NO_CK_PTS125Sx43PSMTR
+- SW_Push_1P1T_NO_CK_PTS125Sx85PSMTR
+- SW_Push_1P1T_NO_CK_PTS125Sx73PSMTR
+- SW_Push_1P1T_NO_CK_PTS125Sx43SMTR
+- SW_Push_1P1T_NO_CK_PTS125Sx85SMTR
+- SW_Push_1P1T_NO_CK_PTS125Sx73SMTR
+- Panasonic_EVQPUJ_EVQPUA
+- Panasonic_EVQPUK_EVQPUB
+- Panasonic_EVQPUL_EVQPUC
+- Panasonic_EVQPUM_EVQPUD
+- SW_SPST_EVQP7A
+- SW_SPST_EVQP7C
+- SW_SPST_B3U-3000P-B
+- SW_SPST_B3U-3000P
+- SW_SPST_B3U-3100P-B
+- SW_SPST_B3U-3100P
+- SW_Push_1P1T-SH_NO_CK_KMR2xxG
+- SW_Push_1P1T_NO_CK_KMR2
+- SW_SPST_PTS810
+</details>
+
+<details>  
+  <summary>THT tactile buttons</summary>
+      
+- SW_TH_Tactile_Omron_B3F-10xx
+- SW_TH_Tactile_Omron_B3F-11xx
+- SW_Tactile_Straight_KSA0Axx1LFTR
+- SW_Tactile_Straight_KSL0Axx1LFTR
+- SW_PUSH_6mm_H8.5mm
+- SW_PUSH-12mm
+- SW_PUSH-12mm_Wuerth-430476085716
+</details>
+
+## Running the scripts
+      
+
+to run the script just move to the scripts dir and do:
+
+`..../bin/freecad.exe  main_generator.py  option`       
+
+where *option* is one of *| all | list | filter*      
+- *all* - generate all models    
+- *list* - list all model names     
+- *filter* - a reqular expression matching model names in the models list above (not case sensitive)   
+     
+examples in win:    
+`c:\freecad\bin\freecad main_generator.py sw_push*`            
+`c:\freecad\bin\freecad main_generator.py *B3U*`           
+`c:\freecad\bin\freecad main_generator.py all`        
+        
+in linux:   
+`freecad ./main_generator.py *tactile*`           
+`freecad ./main_generator.py *evqp*`          
+`freecad ./main_generator.py list`              
+       
+         
+When running the script with no arguments, no models will be generated and a help text will be displayed in the FreeCAD `report view` window     
+The 3D model files will be saved in:    
+`..\_3Dmodels\Button_Switch_SMD.3dshapes`    
+`..\_3Dmodels\Button_Switch_THT.3dshapes`    
+
+

--- a/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_base_model.py
+++ b/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_base_model.py
@@ -1,0 +1,927 @@
+#!/usr/bin/python
+# -*- coding: utf8 -*-
+#
+
+#****************************************************************************
+#*                                                                          *
+#* base classes for generating part models in STEP AP214                    *
+#*                                                                          *
+#* This is part of FreeCAD & cadquery tools                                 *
+#* to export generated models in STEP & VRML format.                        *
+#*   Copyright (c) 2017                                                     *
+#* Terje Io https://github.com/terjeio                                      *
+#* Maurice https://launchpad.net/~easyw                                     *
+#*                                                                          *
+#*   Copyright (c) 2020                                                     *
+#* Mountyrox   https://github.com/mountyrox                                 *
+#*                                                                          *
+#*                                                                          *
+#* All trademarks within this guide belong to their legitimate owners.      *
+#*                                                                          *
+#*   This program is free software; you can redistribute it and/or modify   *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)     *
+#*   the License, or (at your option) any later version.                    *
+#*   for detail see the LICENCE text file.                                  *
+#*                                                                          *
+#*   This program is distributed in the hope that it will be useful,        *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+#*   GNU Library General Public License for more details.                   *
+#*                                                                          *
+#*   You should have received a copy of the GNU Library General Public      *
+#*   License along with this program; if not, write to the Free Software    *
+#*   Foundation, Inc.,                                                      *
+#*   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA           *
+#*                                                                          *
+#****************************************************************************
+
+# 2020-10-27
+
+#
+# parts of this code is based on work by other contributors
+#
+
+import cadquery as cq
+import FreeCAD
+
+from math import sin, cos, tan, radians, atan2
+
+class Polyline:
+    r"""A class for creating a polyline wire (including arcs) using **relative** moves (turtle graphics style)
+
+    Most of the methods returns a reference to the class instance (self) which allows method chaining
+    """
+
+    def __init__(self, plane, origin=(0.0, 0.0)):
+        self.commands = []
+        self.plane = plane
+        self.origin = origin
+        self.x = 0.0
+        self.y = 0.0
+        self.addMoveTo(origin[0], origin[1])
+
+    def getCurrentPosition(self):
+        r"""get the current position in absolute coordinates
+
+        :rtype: Point
+        """
+        return (self.x, self.y)
+
+
+    def addMoveTo(self, x, y):
+        r"""add a relative move (offset) from the current coordinate
+
+        .. note:: when issued as the first call after instatiating the class then the origin is moved accordingly
+
+        :param x: x distance from current position
+        :type  x: ``float``
+        :param y: y distance from current position
+        :type  y: ``float``
+
+        :rtype: self
+        """
+        self.x += x
+        self.y += y
+
+        if len(self.commands) == 1:
+            self.commands = []
+            self.origin = (self.x, self.y)
+        self.commands.append((0, self.x, self.y))
+
+        return self
+
+    def addPoint(self, x, y):
+        r"""add a straight line to point
+
+        :param x: x distance from current position
+        :type  x: ``float``
+        :param y: y distance from current position
+        :type  y: ``float``
+
+        :rtype: self
+        """
+        self.x += x
+        self.y += y
+        self.commands.append((1, self.x, self.y))
+
+        return self
+
+    def addPoints(self, pointList):
+        r"""add a list of new points
+
+        :param pointList:
+        :type  pointList: list of points
+
+        :rtype: self
+
+        Example where first half is defined by points and then mirrored by adding points in reverse order::
+
+            ow = 0.6
+            pw = self.pin_width
+            c1 = (ow - pw) / 2.0
+            pin = Polyline(cq.Workplane("XY"), origin=(0.0, self.body_width / 2.0))\
+                             .addPoints([
+                                    (ow / 2.0, 0),
+                                    (0.0, -self.body_width),
+                                    (-c1, -c1),
+                                    (0.0, -(self.pin_length - pw)),
+                                    (-pw / 4.0, -pw),
+                                    (-pw / 4.0, 0.0),
+                               ])\
+                             .addMirror().make().extrude(self.pin_thickness)
+
+        .. figure::  ../images/pin.png
+
+           Rendering
+        """
+
+        for point in pointList:
+            self.addPoint(point[0], point[1])
+
+        return self
+
+    def addArc(self, radius, angle=90, type=0):
+        r"""Adds an arc to the polygon wire.
+        Hint: If the arc angle is less than 90 degree the connection of the arc to the privious/next polyline segment 
+        will not be tangential. To get tangential connections use ``addRadiusArc`` instead.
+
+        :param radius: radius of the arc
+        :type  radius: ``float``
+
+        :rtype: ``self``
+        """
+
+        o = sin(radians(abs(angle) / 2.0))
+        p = 1.0 - 1.0 * o
+        f = -1.0 if angle < 0.0 else 1.0
+
+        if type == 0:
+            ap1 = self.x + radius * (p if f == 1.0 else o)
+            ap2 = self.y + radius * (o if f == 1.0 else p) * f
+        else:
+            ap1 = self.x + radius * (p if f == -1.0 else o)
+            ap2 = self.y + radius * (o if f == -1.0 else p) * f
+        self.x += radius
+        self.y += radius * f
+        self.commands.append((2, self.x, self.y, ap1, ap2))
+
+        return self
+
+
+    def addRadiusArc(self, x, y, radius):
+        r"""Adds an arc to the polygon wire.
+
+        :param  x: the x coordinate of the end point of the arc
+        :type   x: ``float``
+        :param  y: the y coordinate of the end point of the arc
+        :type   y: ``float``
+        :param radius: radius of the arc
+        :type  radius: ``float``
+
+        :rtype: ``self``
+        """
+        self.x += x
+        self.y += y
+        self.commands.append((3, self.x, self.y, radius))
+
+        return self
+
+
+    def addThreePointArc(self, point1, point2):
+        r"""create a three point arc
+
+        The starting point is the current position, end point is *point2*, the arc will be drawn through point1
+
+        :param point1:
+        :type  width: ``float``
+
+        :param point2:
+        :type  point2: ``point``
+
+        :rtype: self
+
+        Example::
+
+            l = 4
+            a = 0.2
+            w = 2 - a
+
+            body = Polyline(cq.Workplane("XY"))\
+                              .addPoint(0, w)\
+                              .addThreePointArc((l / 2, a), (l, 0))\
+                              .addPoint(0,- w).make().extrude(1)
+
+        .. figure::  ../images/threepointarc.png
+
+           Rendering
+
+        """
+        ap1 = self.x + point1[0]
+        ap2 = self.y + point1[1]
+        self.x += point2[0]
+        self.y += point2[1]
+        self.commands.append((2, self.x, self.y, ap1, ap2))
+
+        return self
+
+    def addChamferedRectangle(self, length, width, chamfer):
+        r"""create a chamfered rectangle centered at the current point
+
+        :param length:
+        :type  length: ``float``
+
+        :param width:
+        :type  width: ``float``
+
+        :param chamfer:
+        :type  chamfer: ``float``
+
+        :rtype: self
+
+        See :func:`addRoundedRectangle` for an example
+        """
+
+        self.addMoveTo(-length / 2.0, -width / 2.0 + chamfer)
+
+        length = length - chamfer * 2.0
+        width = width - chamfer * 2.0
+
+        self.addPoint(0.0, width)
+        self.addPoint(chamfer, chamfer)
+        self.addPoint(length, 0)
+        self.addPoint(chamfer, -chamfer)
+        self.addPoint(0.0, -width)
+        self.addPoint(-chamfer, -chamfer)
+        self.addPoint(-length, 0.0)
+        self.addPoint(-chamfer, chamfer)
+
+        return self
+
+    def addRoundedRectangle(self, length, width, radius):
+        r"""create a rounded rectangle centered at the current point
+
+        :param length:
+        :type  length: ``float``
+
+        :param width:
+        :type  width: ``float``
+
+        :param cornerRadius:
+        :type  cornerRadius: ``float``
+
+        :rtype: self
+
+        Example with a chamfered rectangle cutout::
+
+            l = 4
+            w = 2
+
+            cutout = Polyline(cq.Workplane("XY"))\
+                        .addChamferedRectangle(l - 0.3, w - 0.3, 0.3).make().extrude(1)
+
+            body = Polyline(cq.Workplane("XY"))\
+                        .addRoundedRectangle(l, w, 0.3).make().extrude(1).cut(cutout)
+
+        .. figure::  ../images/roundedrectangle.png
+
+           Rendering
+        """
+
+        self.addMoveTo(-length / 2.0, -width / 2.0 + radius)
+
+        length = length - radius * 2.0
+        width = width - radius * 2.0
+
+        self.addPoint(0.0, width)
+        self.addArc(radius, 90)
+        self.addPoint(length, 0)
+        self.addArc(radius, -90)
+        self.addPoint(0.0, -width)
+        self.addArc(-radius, 90)
+        self.addPoint(-length, 0.0)
+        self.addArc(-radius, -90)
+
+        return self
+
+    def mirror(self, axis="X"):
+        r"""mirror the current polyline
+        """
+
+        result = []
+        tx = -1.0 if axis == "X" else 1.0
+        ty = -1.0 if axis != "X" else 1.0
+
+        for point in self.commands:
+            result.append((point[0], point[1] * tx, point[2] * ty))
+
+        self.commands = result
+
+        return self
+
+    def addMirror(self, axis="X"):
+        r"""add a mirror of the current polyline by reversing its direction. Can only be used for straight lines, 
+        not if arcs are added into the polyline.
+        """
+
+        x0 = self.origin[0] if axis == "X" else 0.0
+        y0 = self.origin[1] if axis != "X" else 0.0
+        tx = -1.0 if axis == "X" else 1.0
+        ty = -1.0 if axis != "X" else 1.0
+        start = 2 #if axis == "X" else 0
+        start = 1 if self.commands[0][start] == self.commands[-1][start] else 0
+
+        for point in reversed(self.commands[start:-1]):
+            self.commands.append((1, (point[1] - x0) * tx + x0, (point[2] - y0) * ty + y0))
+
+        return self
+
+    def _is_equal (self, point1, point2):
+        return point1[0] == point2[0] and point1[1] == point2[1]
+
+    def make(self):
+        r""" Closes the polyline and creates a wire in the supplied plane
+
+        :rtype: ``wire``
+        """
+        plane = self.plane
+
+        for point in self.commands:
+            if point[0] == 0:
+                plane = plane.moveTo(point[1], point[2])
+            elif point[0] == 1:
+                plane = plane.lineTo(point[1], point[2])
+            elif point[0] == 2:
+                plane = plane.threePointArc((point[3], point[4]), (point[1], point[2]))
+            elif point[0] == 3:
+                plane = plane.radiusArc((point[1], point[2]), point[3]) 
+
+        return plane.wire() if self._is_equal(self.origin, (self.commands[-1])[1:3]) else plane.close().wire()
+
+
+class PartBase (object):
+    """Base class for model creation, to be subclassed
+
+    .. document private functions
+    .. automethod:: _union_all
+    .. automethod:: _mirror
+    .. automethod:: _make_gullwing_pin
+    .. automethod:: _make_Jhook_pin
+    .. automethod:: _make_straight_pin
+    .. automethod:: _make_angled_pin
+    .. automethod:: _make_plastic_body
+    """
+    #
+    destination_dir = "My.3dshapes"
+    #
+    #############################################
+    # Licence information of the generated models
+    #############################################
+    licAuthor = "kicad StepUp"
+    licEmail = "ksu"
+    licOrgSys = "kicad StepUp"
+    licPreProc = "OCC"
+    licOrg = "FreeCAD"
+    #############################################
+
+    def __init__(self, params):
+        # init mandatory base class attributes to some more or less sensible defaults
+        self.footprints_dir = None
+
+        self.rotation = 0
+        self.make_me = True
+
+        args = params._asdict()
+        self.type = params.type if 'type' in args and params.type != None else "SMD"
+
+        self.pin_width = params.pin_width if 'pin_width' in args and  params.pin_width != None else 0.4
+        self.pin_thickness = params.pin_thickness if 'pin_thickness' in args and  params.pin_thickness != None else 0.2
+        self.pin_length = params.pin_length if 'pin_length' in args and  params.pin_length != None else 3.2
+        self.pin_pitch = params.pin_pitch if 'pin_pitch' in args and  params.pin_pitch != None else 2.54
+        self.num_pins = params.num_pins if 'num_pins' in args and  params.num_pins != None else 2
+        self.num_pin_rows = params.num_pin_rows if 'num_pin_rows' in args and  params.num_pin_rows != None else 2
+        self.pin_rows_distance = params.pin_rows_distance if 'pin_rows_distance' in args and  params.pin_rows_distance != None else self.pin_pitch
+        self.tht_pin_clamp_extension = params.tht_pin_clamp_extension if 'tht_pin_clamp_extension' in args and  params.tht_pin_clamp_extension != None else 0.45
+        self.tht_pin_lower_clamp_angel = params.tht_pin_lower_clamp_angel if 'tht_pin_lower_clamp_angel' in args and  params.tht_pin_lower_clamp_angel != None else 50.0
+
+
+        self.body_width = params.body_width if 'body_width' in args and  params.body_width != None else 6.0
+        self.body_length = params.body_length if 'body_length' in args and  params.body_length != None else 6.0
+        self.body_height = params.body_height if 'body_height' in args and  params.body_height != None else 3.5
+        self.first_pin_pos = (0.0, 0.0) if self.num_pins is None else (self.pin_pitch * (self.num_pins / 2.0 / self.num_pin_rows - 0.5), self.pin_rows_distance / 2.0)
+        self.offsets = (0.0, 0.0, 0.0)
+
+    def say (self, msg):
+        FreeCAD.Console.PrintMessage("##: " + str(msg) + '\n')
+
+    def isValidModel (self):
+        return self.make_me
+
+    def _union_all(self, objects):
+        o = objects[0]
+        for i in range(1, len(objects)):
+            o = o.union(objects[i])
+        return o
+
+    def _mirror(self, obj, pins=None, pitch=None):
+
+        if pins is None:
+            pins = self.num_pins // 2
+
+        if pitch is None:
+            pitch = self.pin_pitch
+
+        objs = [obj]
+        for i in range(2, pins + 1):
+            objs.append(obj.translate((-pitch * (i - 1), 0, 0)))
+
+        return self._union_all(objs)
+
+    def _make_plastic_body(self, pin_area_height=None, body_angle_top=12.0, body_angle_bottom=12.0):
+        """ create straight pin
+
+        The pin will placed at coordinate 0, 0 and with the base at Z = 0
+
+        :param pin_height: overall pin height
+        :type pin_height: ``float``
+
+        :rtype: ``solid``
+
+        .. figure::  ../images/plasticbody.png
+
+           Rendering example
+
+        """
+
+        self.say('\n###: ' + str(pin_area_height) + " " + str( body_angle_top))
+
+        if pin_area_height is None:
+            pin_area_height = self.pin_thickness             # top part of body is that much smaller
+
+        the_t = 2.0 * tan(radians(body_angle_top))           # body angle top
+        the_b = 2.0 * tan(radians(body_angle_bottom))        # body angle bottom
+
+        A2_t = (self.body_height - pin_area_height) / 2.0    # body top part height
+        A2_b = A2_t                                          # body bottom part height
+        D_b = self.body_length - the_b * A2_b                # bottom length
+        E1_b = self.body_width - the_b * A2_b                # bottom width
+        D_t1 = self.body_length - pin_area_height            # top part bottom length
+        E1_t1 = self.body_width - pin_area_height            # top part bottom width
+        D_t2 = D_t1 - the_t * A2_t                           # top part upper length
+        E1_t2 = E1_t1 - the_t * A2_t                         # top part upper width
+
+        self.body_edge_upper = E1_t2 / 2.0 # save for pin mark placement
+
+        return cq.Workplane(cq.Plane.XY())\
+                 .rect(D_b, E1_b)\
+                 .workplane(offset=A2_b).rect(self.body_length, self.body_width)\
+                 .workplane(offset=pin_area_height).rect(self.body_length, self.body_width)\
+                 .rect(D_t1, E1_t1)\
+                 .workplane(offset=A2_t).rect(D_t2, E1_t2).loft(ruled=True)
+
+    def _make_straight_pin(self, pin_height=None, style='Rectangular'):
+        """ create straight pin
+
+        The pin will placed at coordinate 0, 0 and with the base at Z = 0
+
+        :param pin_height: overall pin height
+        :type pin_height: ``float``
+
+        :rtype: ``solid``
+
+        .. figure::  ../images/straightpin.png
+
+           Rendering example
+
+        """
+        if pin_height is None:
+            pin_height = self.pin_length + self.body_board_distance
+
+        return Polyline(cq.Workplane("XZ").workplane(offset=-self.pin_thickness / 2.0))\
+                          .addPoints([
+                                (self.pin_width / 2.0, 0.0),
+                                (0.0, -(pin_height - self.pin_width)),
+                                (-self.pin_width / 4.0, -self.pin_width),
+                                (-self.pin_width / 4.0, 0.0),
+                            ]).addMirror().make().extrude(self.pin_thickness)
+
+    def _make_angled_pin(self, pin_height=None, top_length=0.0, top_extension=0.0, style='SMD'):
+        """ create angled pin
+
+        The pin will placed with center of top part at coordinate 0, 0 and with the base at Z = 0.
+        The top part with length ``top_length`` is oriented downwards Z and the part with length ``pin_height`` points into Y direction.
+
+        :param pin_height: overall pin height, from pin tip to outer surface of top part
+        :type pin_height: ``float``
+
+        :rtype: ``solid``
+
+        .. figure::  ../images/angledsmdpin.png
+
+           Rendering example, SMD style
+
+        .. figure::  ../images/angledthtpin.png
+
+           Rendering example, THT style
+
+        """
+        if pin_height is None:
+            pin_height = self.pin_length
+
+        d = self.pin_width / 10.0
+        r_i = self.pin_thickness / 2.0
+        r_o = r_i + self.pin_thickness # pin lower corner, outer radius
+
+        if style == 'SMD': # make a horizontal pin
+            pin = Polyline(cq.Workplane("XY").workplane(offset=-r_o), origin=(0.0, r_o))\
+                             .addMoveTo(-self.pin_width / 2.0, 0.0)\
+                             .addPoint(d, self.pin_length - d)\
+                             .addThreePointArc((self.pin_width / 2.0 - d, d), (self.pin_width - d * 2.0, 0.0))\
+                             .addPoint(d, -self.pin_length + d).make().extrude(self.pin_thickness)
+
+        else: # make a vertical pin
+            pin = self._make_straight_pin(pin_height-r_o)\
+                      .rotate((0,0,0), (1,0,0), 90)\
+                      .translate((0, r_o, - self.pin_thickness))
+
+        # make the arc joining the pin segments
+        arc = Polyline(cq.Workplane("YZ").workplane(offset=-self.pin_width / 2.0))\
+                         .addArc(r_o, -90, 1)\
+                         .addPoint(0, self.pin_thickness)\
+                         .addArc(-r_i, -90).make().extrude(self.pin_width)
+        
+        pin = pin.union(arc).translate((0, -self.pin_thickness / 2, -top_length))
+
+        if(round(top_length, 6) != 0.0):
+            pin = pin.union(cq.Workplane("XZ")\
+                     .workplane(offset=-self.pin_thickness / 2)\
+                     .moveTo(self.pin_width / 2.0, r_o-(top_length + r_o))\
+                     .line(0, top_length)\
+                     .line(-self.pin_width, 0)\
+                     .line(0, -top_length)\
+                     .close().extrude(self.pin_thickness))
+        elif (round(top_extension, 6) != 0.0):
+            pin = pin.union(cq.Workplane("XZ")\
+                     .workplane(offset=-self.pin_thickness / 2)\
+                     .moveTo(self.pin_width / 2.0, 0.0)\
+                     .line(0.0, top_extension)\
+                     .line(-self.pin_width, 0.0)\
+                     .line(0.0, -top_extension)\
+                     .close().extrude(self.pin_thickness))
+        
+        
+        return pin
+
+
+    def _make_angled_clamping_pin(self, pin_height, top_length=0.0, tht_pin_clamp_extension=0.45, tht_pin_lower_clamp_angel=50.0):
+        """ create angled THT pin with asymetrical lambda shaped clamp 
+
+        The pin will placed at coordinate 0, 0 and with the base at Z = 0
+
+        :param pin_height: overall pin height, from pin tip to outer surface of top part
+        :type pin_height: ``float``
+        :param top_length: top length of pin height, measured from arc to end og top part. Default value: 0.0
+        :type top_length: ``float``
+        :param tht_pin_clamp_extension: width of clamp. For a straight pin this value would be 0.0 (0.0 is not allowed). Default value: 0.45
+        :type tht_pin_clamp_extension: ``float``
+        :param tht_pin_lower_clamp_angel: angle between lover clamp leg an straight part of pin tip. Default value: 50 degree
+        :type tht_pin_lower_clamp_angel: ``float``
+
+        :rtype: ``solid``
+
+        """
+
+        # the following radii will only be uses to connect top part of pin (pin_length) and lower part of pin (pin_height)
+        # the inner angles of the clamp will be done by fillet
+        r_i = self.pin_thickness / 2.0
+        r_o = r_i + self.pin_thickness 
+
+        # The pin is getting smaller at the tip. The projected length of this tip part is equal to the pin width. 
+        # Therefore the part of the pin with constant width is: pin_height - self.pin_width
+        # Additionally we have to consider the upper arc:  pin_height_without_tip = pin_height - self.pin_width - 'fraction of arc radius'
+
+        # clamp angle (alpha) to tip of pin.
+        alpha = radians (tht_pin_lower_clamp_angel)
+        sa = sin(alpha)
+        ca = cos(alpha)
+        ta = tan(alpha)
+        # the straight part of pin below the clamp should be smaller as the clamp angle is smaller, beween 0.3 ... 0.15.
+        # We take clamp angle / 175.0 of the height, but not less than pin width (see comment above)
+        s = max (tht_pin_lower_clamp_angel / 175.0 * pin_height, self.pin_width)
+
+        # projected height of lower part of clamp is:
+        hl = tht_pin_clamp_extension / ta
+        # projection height of the upper part of clamp we call hu. The corresponding angle beta has to be calculated. 
+        # The height of the pin can be written as: H = s + hl + hu + 'fraction of arc radius'. The fraction of arc radius is: r_o * (1-cos(90-beta)) = r_o * (1-sin(beta)).
+        # With (hu = tht_pin_clamp_extension / tan(beta) we get: H = s + hl + tht_pin_clamp_extension / tan(beta) + r_o * (1-sin(beta))
+        # This equation could be used to calculate the angle beta, but we must solve a nonlinear equation to the power of four
+        # Following approximation can be used: Instead of using the correct fraction of the arc radius we use the complete radius r_o. 
+        # This would result in a pin height which is be a little bit too small. To compensate this we inclease the height of the lower tip part (s) by the missing amount. 
+        hu = pin_height - r_o - s - hl
+        beta = atan2 (tht_pin_clamp_extension, hu)
+        sb = sin (beta)
+        cb = cos (beta)
+        tb = tht_pin_clamp_extension / hu  # tan (beta)
+
+        # This results in a new height, a bit smaller than original height:
+        h = s + hl + hu + r_o * (1.0-sb)
+        # the correction to s is:
+        s += (pin_height - h)
+        # Whwn making the pin no arcs will be used for the inner and outer clamp angles.
+        # The outer corner of the clamp will be rounded by the last fillet command.
+        # When creating the pin, the inner clamp point lies on the bisecting line of angle 180-(alpha+beta).
+        # For creating this point we need the tan((alpha+beta)/2). 
+        # The length of the inner clamp line is 'pin_thickness*tan((alpha+beta)/2)' shorter than the length of the outer clamp line.
+        tbl = tan ((alpha+beta)/2.0)
+        dl = self.pin_thickness * tbl
+        pin = Polyline(cq.Workplane("YZ").workplane(offset=-self.pin_width / 2.0), origin=(r_o * (1.0-sb), -r_o*cb))\
+                            .addPoint(hu, -tht_pin_clamp_extension)\
+                            .addPoint(hl, +tht_pin_clamp_extension)\
+                            .addPoint(0.0, self.pin_thickness)\
+                            .addRadiusArc(-self.pin_thickness * sa, -self.pin_thickness * (1.0 - ca), -self.pin_thickness)\
+                            .addPoint(-(hl - dl*ca), -(tht_pin_clamp_extension - dl*sa))\
+                            .addPoint(-(hu - dl*cb), +(tht_pin_clamp_extension - dl*sb))\
+                            .make().extrude(self.pin_width).edges("<Z").fillet(self.pin_thickness)
+
+        # make pin tip with overall length s
+        tip = Polyline(cq.Workplane("XY").workplane(offset=-r_o*cb))\
+                          .addMoveTo(0.0, (hl + hu + r_o * (1.0-sb)))\
+                          .addPoints([
+                                (self.pin_width / 2.0, 0.0),
+                                (0.0, (s - self.pin_width)),
+                                (-self.pin_width / 4.0, self.pin_width),
+                                (-self.pin_width / 4.0, 0.0),
+                            ]).addMirror().make().extrude(self.pin_thickness)
+
+        pin = pin.union(tip)
+
+        # make the arc to connect top part of pin
+        arc = Polyline(cq.Workplane("YZ").workplane(offset=-self.pin_width / 2.0))\
+                         .addRadiusArc(r_o * (1.0-sb), -r_o * cb, -r_o)\
+                         .addPoint(self.pin_thickness * sb, self.pin_thickness * cb)\
+                         .addRadiusArc(-r_i * (1.0-sb), r_i * cb, r_i).make().extrude(self.pin_width)
+
+        pin = pin.union(arc).translate((0, -self.pin_thickness / 2, -top_length))
+
+        # make the top part of the pin
+        if(round(top_length, 6) != 0.0):
+            pin = pin.union(cq.Workplane("XZ")\
+                     .workplane(offset=-self.pin_thickness / 2)\
+                     .moveTo(self.pin_width / 2.0, r_o-(top_length + r_o))\
+                     .line(0, top_length)\
+                     .line(-self.pin_width, 0)\
+                     .line(0, -top_length)\
+                     .close().extrude(self.pin_thickness))
+
+        return pin
+
+    def _make_angled_lambda_pin(self, pin_height, top_length=0.0, tht_pin_clamp_extension=0.45):
+        """ create angled THT pin with symetrical lambda shaped clamp 
+
+        The pin will placed at coordinate 0, 0 and with the base at Z = 0
+
+        :param pin_height: overall pin height, from pin tip to outer surface of top part
+        :type pin_height: ``float``
+        :param top_length: top length of pin height, measured from arc to end og top part. Default value: 0.0
+        :type top_length: ``float``
+        :param tht_pin_clamp_extension: width of clamp. For a straight pin this value would be 0.0 (0.0 is not allowed). Default value: 0.45
+        :type tht_pin_clamp_extension: ``float``
+
+        :rtype: ``solid``
+
+        """
+
+        # the following radii will only be uses to connect top part of pin (pin_length) and lower part of pin (pin_height)
+        # the inner angles of the clamp 
+        r_i = self.pin_thickness / 2.0
+        r_o = r_i + self.pin_thickness 
+        
+        # The pin is getting smaller at the tip. The projected length of this tip part is equal to the pin width. 
+        # Therefore the part of the pin with constant height is: pin_height - self.pin_width.
+        # Additionally the height is measured from tip to outer surface of top part of pin, we must subtract the outer radius
+        pin_height_without_tip = pin_height - self.pin_width - r_o
+        # projected heigth of halve the clamp is:
+        q = 0.35  # fraction of clamp compared to the pin_height_without_tip. The smaler the value the steeper the clamp   
+        d = pin_height_without_tip * q  # 2*d is height of clamp
+        
+        # clamp angle (alpha):
+        alpha = atan2 (tht_pin_clamp_extension, d)
+        ca = cos(alpha)
+        sa = sin(alpha)
+        ta = tht_pin_clamp_extension / d  # tan (alpha)
+
+        s = (pin_height_without_tip - 2.0 * d) / 6.0  # rest of pin hight 5/6 above clamp 1/6 below
+        
+        # make clamp part of pin. For the inner angles of the clamp no arcs will be used.
+        # The same for the outer corner of the clamp, it will be rounded by the last fillet command.
+        pin = Polyline(cq.Workplane("YZ").workplane(offset=-self.pin_width / 2.0), origin=(r_o, -r_o))\
+                            .addPoint(5.0 * s, 0.0)\
+                            .addPoint(d, -tht_pin_clamp_extension)\
+                            .addPoint(d, +tht_pin_clamp_extension)\
+                            .addPoint(s, 0.0)\
+                            .addPoint(0.0, self.pin_thickness)\
+                            .addPoint(-s, 0.0)\
+                            .addRadiusArc(-self.pin_thickness * sa, -self.pin_thickness * (1.0 - ca), -self.pin_thickness)\
+                            .addPoint(-(d - self.pin_thickness * sa), -(tht_pin_clamp_extension - self.pin_thickness * (1.0/ca - ca)))\
+                            .addPoint(-(d - self.pin_thickness * sa), +(tht_pin_clamp_extension - self.pin_thickness * (1.0/ca - ca)))\
+                            .addRadiusArc(-self.pin_thickness * sa, +self.pin_thickness * (1.0 - ca), -self.pin_thickness)\
+                            .addPoint(-5.0 * s, 0.0)\
+                            .make().extrude(self.pin_width).edges("<Z").fillet(0.2)
+
+        tip = Polyline(cq.Workplane("XY").workplane(offset=-self.pin_thickness * 1.5))\
+                          .addMoveTo(0.0, pin_height_without_tip + r_o)\
+                          .addPoints([
+                                (self.pin_width / 2.0, 0.0),
+                                (-self.pin_width / 4.0, self.pin_width),
+                                (-self.pin_width / 4.0, 0.0),
+                            ]).addMirror().make().extrude(self.pin_thickness)
+
+        pin = pin.union(tip)
+
+        # make the arc to connect top part of pin
+        arc = Polyline(cq.Workplane("YZ").workplane(offset=-self.pin_width / 2.0))\
+                         .addArc(r_o, -90, 1)\
+                         .addPoint(0, self.pin_thickness)\
+                         .addArc(-r_i, -90).make().extrude(self.pin_width)
+
+        pin = pin.union(arc).translate((0, -self.pin_thickness / 2, -top_length))
+
+        # make the top part of the pin
+        if(round(top_length, 6) != 0.0):
+            pin = pin.union(cq.Workplane("XZ")\
+                     .workplane(offset=-self.pin_thickness / 2)\
+                     .moveTo(self.pin_width / 2.0, r_o-(top_length + r_o))\
+                     .line(0, top_length)\
+                     .line(-self.pin_width, 0)\
+                     .line(0, -top_length)\
+                     .close().extrude(self.pin_thickness))
+     
+        
+        return pin
+
+    def _make_gullwing_pin(self, pin_height, bottom_length, r_upper_i=None, r_lower_i=None):
+        """ create gull wing pin
+
+        The pin will placed at coordinate 0, 0 and with the base at Z = 0
+
+        :param pin_height: overall pin height
+        :type pin_height: ``float``
+
+        :rtype: ``solid``
+
+        .. figure::  ../images/gullwingpin.png
+
+           Rendering example
+
+        """
+
+        # r_upper_i - pin upper corner, inner radius
+        # r_lower_i - pin lower corner, inner radius
+        # bottom_length - pin bottom flat part length (excluding corner arc)
+
+        if r_lower_i is None:
+            r_lower_i = self.pin_thickness / 2.0 if r_upper_i is None else r_upper_i
+
+        if r_upper_i is None:
+            r_upper_i = self.pin_thickness / 2.0
+
+        r_lower_i = max (r_lower_i, 0.0001)
+        r_upper_i = max (r_upper_i, 0.0001)
+        r_upper_o = r_upper_i + self.pin_thickness # pin upper corner, outer radius
+        r_lower_o = r_lower_i + self.pin_thickness # pin lower corner, outer radius
+        bottom_length = max (bottom_length - r_lower_i, 0.000001)
+        top_length = max (self.pin_length - bottom_length - r_upper_i - r_lower_o, 0.0001)
+
+        return Polyline(cq.Workplane("YZ"), origin=(0, pin_height))\
+                          .addPoint(top_length, 0)\
+                          .addArc(r_upper_i, -90)\
+                          .addPoint(0, -(pin_height - r_upper_i - r_lower_o))\
+                          .addArc(r_lower_o, -90, 1)\
+                          .addPoint(bottom_length, 0)\
+                          .addPoint(0, self.pin_thickness)\
+                          .addPoint(-bottom_length, 0)\
+                          .addArc(-r_lower_i, -90)\
+                          .addPoint(0, pin_height - r_upper_i - r_lower_o)\
+                          .addArc(-r_upper_o, -90, 1)\
+                          .addPoint(-top_length, 0).make().extrude(self.pin_width).translate((-self.pin_width / 2.0, 0, 0))
+
+
+    def _make_angular_gullwing_pin(self, pin_height, bottom_length, pin_angle=65.0, r_upper_i=None, r_lower_i=None):
+        """ create an angular gull wing pin
+
+        The pin will be placed at coordinate 0, 0 and with the base at Z = 0
+
+        :param pin_height: overall pin height (measured from upper leg bottom to lower leg bottom)
+        :type pin_height: ``float``
+        :param bottom_length: bottom length of gullwing pin (measured from end of pin to begin of arc)
+        :type bottom_length: ``float``
+        :param pin_angle: angle between horizontal and mid part of pin (for vertical bent pin angle is 90 deg).
+                          Minimum angle is 20 deg, lower angles will be set to default (65 deg)
+        :type pin_angle: ``float``
+        :rtype: ``solid``
+        """
+
+        # r_upper_i - pin upper corner, inner radius
+        # r_lower_i - pin lower corner, inner radius
+        # bottom_length - pin bottom flat part length (excluding corner arc)
+
+        if r_lower_i is None:
+            r_lower_i = self.pin_thickness / 2.0 if r_upper_i is None else r_upper_i
+
+        if r_upper_i is None:
+            r_upper_i = self.pin_thickness / 2.0
+
+        if pin_angle <= 20.0:
+             pin_angle = 65.0
+
+        ca = cos(radians (pin_angle))
+        sa = sin(radians (pin_angle))
+
+        r_upper_o = r_upper_i + self.pin_thickness # pin upper corner, outer radius
+        r_lower_o = r_lower_i + self.pin_thickness # pin lower corner, outer radius
+        
+        # The bottom length given to the function is the lenghth from half the outer bend radius to end of pin.
+        # The straight part has to be removed by this half outer bend radius.
+        bottom_length = bottom_length - (r_lower_o  * sin(radians (pin_angle/2.0)))
+        top_length = self.pin_length - bottom_length - (r_upper_i + r_lower_o) * sa - (pin_height - (r_upper_i + r_lower_o) * (1.0 - ca))/tan(radians (pin_angle))
+        if top_length < 0:
+            self.say('\n###: Combination of pin length and pin angle not possible. Pin angle will be set to 90 deg')
+            top_length = self.pin_length - bottom_length - (r_upper_i + r_lower_o)
+            ca = 0.0
+            sa = 1.0
+
+        vert_center_length = pin_height - (r_upper_i + r_lower_o) * (1.0 - ca)  # vertical length of middle part of pin
+        hor_center_length = self.pin_length - bottom_length - top_length - (r_upper_i + r_lower_o) * sa   # horizontal length of middle part of pin
+        
+
+        return Polyline(cq.Workplane("YZ"), origin=(0, pin_height))\
+                          .addPoint(top_length, 0)\
+                          .addRadiusArc(r_upper_i * sa, -r_upper_i * (1.0 - ca), r_upper_i)\
+                          .addPoint(hor_center_length, -vert_center_length)\
+                          .addRadiusArc(r_lower_o * sa, -r_lower_o * (1.0 - ca), -r_lower_o)\
+                          .addPoint(bottom_length, 0)\
+                          .addPoint(0, self.pin_thickness)\
+                          .addPoint(-bottom_length, 0)\
+                          .addRadiusArc(-r_lower_i * sa, r_lower_i * (1.0 - ca), r_lower_i)\
+                          .addPoint(-hor_center_length, vert_center_length)\
+                          .addRadiusArc(-r_upper_o * sa, r_upper_o * (1.0 - ca), -r_upper_o)\
+                          .addPoint(-top_length, 0).make().extrude(self.pin_width).translate((-self.pin_width / 2.0, 0, 0))
+
+
+
+    def _make_Jhook_pin(self, pin_height, bottom_length, top_length = 0.05, r_upper_i=None, r_lower_i=None):
+        """ create J-hook pin
+
+        The pin will placed at coordinate 0, 0 and with the base at Z = 0
+
+        :param pin_height: overall pin height
+        :type pin_height: ``float``
+
+        :rtype: ``solid``
+
+        .. figure::  ../images/jhookpin.png
+
+           Rendering example
+
+        """
+
+        # r_upper_i - pin upper corner, inner radius
+        # r_lower_i - pin lower corner, inner radius
+        # bottom_length - pin bottom flat part length (excluding corner arc)
+
+        if r_lower_i is None:
+            if r_upper_i is not None and r_upper_i > 0.0:
+                r_lower_i = r_upper_i
+            else:
+                r_lower_i = self.pin_thickness / 2.0 
+
+
+        if r_upper_i is None:
+            r_upper_i = self.pin_thickness / 2.0
+
+        r_upper_o = r_upper_i + self.pin_thickness # pin upper corner, outer radius
+        r_lower_o = r_lower_i + self.pin_thickness # pin lower corner, outer radius
+        bottom_length = bottom_length - r_lower_i
+        
+        pl = Polyline(cq.Workplane("YZ"), (-(top_length + r_upper_i), pin_height))
+        if top_length > 0.0:
+            pl = pl.addPoint(top_length, 0)
+        if r_upper_i > 0.0:
+            pl = pl.addArc(r_upper_i, -90)
+
+        pl = pl.addPoint(0, -(pin_height - r_upper_i - r_lower_i - self.pin_thickness))\
+                          .addArc(-r_lower_i, 90)\
+                          .addPoint(-bottom_length, 0)\
+                          .addPoint(0, -self.pin_thickness)\
+                          .addPoint(bottom_length, 0)\
+                          .addArc(r_lower_o, 90, 1)\
+                          .addPoint(0, pin_height - r_upper_i - r_lower_i - self.pin_thickness)
+                          
+        if top_length > 0.0:
+            pl = pl.addArc(-r_upper_o, -90, 1).addPoint(-top_length, 0)
+
+        pl = pl.make()
+        pl = pl.extrude(self.pin_width)
+        pl = pl.translate((-self.pin_width / 2.0, 0, 0))
+        return pl
+
+### EOF ###

--- a/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_base_tact_switches.py
+++ b/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_base_tact_switches.py
@@ -1,0 +1,1841 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# This script is derived from a script for generating  DIP_parts and Buzzer_Beeper scripts
+#
+# Dimensions are from data sheets given in the settings of the corresponding KiCad footprint:
+
+## requirements
+## cadquery FreeCAD plugin
+##   https://github.com/jmwright/cadquery-freecad-module
+
+## to run the script just do: freecad main_generator.py modelName
+## e.g. c:\freecad\bin\freecad main_generator.py *b3fs*
+
+## the script will generate STEP and VRML parametric models
+## to be used with kicad StepUp script
+
+#* These are a FreeCAD & cadquery tools                                     *
+#* to export generated models in STEP & VRML format.                        *
+#*                                                                          *
+#* cadquery script for generating QFP/SOIC/SSOP/TSSOP models in STEP AP214  *
+#*   Copyright (c) 2015                                                     *
+#* Maurice https://launchpad.net/~easyw                                     *
+#*                                                                          *
+#*   Copyright (c) 2020                                                     *
+#* Mountyrox   https://github.com/mountyrox                                 *
+#*                                                                          *
+#* All trademarks within this guide belong to their legitimate owners.      *
+#*                                                                          *
+#*   This program is free software; you can redistribute it and/or modify   *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)     *
+#*   as published by the Free Software Foundation; either version 2 of      *
+#*   the License, or (at your option) any later version.                    *
+#*   for detail see the LICENCE text file.                                  *
+#*                                                                          *
+#*   This program is distributed in the hope that it will be useful,        *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+#*   GNU Library General Public License for more details.                   *
+#*                                                                          *
+#*   You should have received a copy of the GNU Library General Public      *
+#*   License along with this program; if not, write to the Free Software    *
+#*   Foundation, Inc.,                                                      *
+#*   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA           *
+#*                                                                          *
+#****************************************************************************
+import operator
+
+import cadquery as cq
+from Helpers import show
+
+import FreeCAD, Draft, FreeCADGui
+import ImportGui
+import FreeCADGui as Gui
+
+import shaderColors
+import exportPartToVRML as expVRML
+
+# Import cad_tools
+import cq_cad_tools
+# Reload tools
+from cq_cad_tools import reload_lib
+reload_lib(cq_cad_tools)
+# Explicitly load all needed functions
+from cq_cad_tools import FuseObjs_wColors, GetListOfObjects, z_RotateObject, Color_Objects, restore_Main_Tools, exportSTEP, saveFCdoc
+
+import cq_parameters  # modules parameters
+from cq_parameters import ShapeOfTerminal, ButtonType, partParamsTactSwitches, ButtonRing
+
+import collections
+from collections import namedtuple
+
+
+from  cq_base_model import PartBase, Polyline  # modules parameters
+
+class TactSwitchSeries:
+    r"""A class for holding Omron tactile switch series
+
+    .. note:: will be changed to enum when Python version allows it
+    """
+    # Omron series
+    B3F = 'B3F'
+    r"""B3F: Through hole-mounting switches
+    """
+    B3U1 = 'B3U1'
+    r"""B3U1: Ultra-small Surface-mounting Tactile
+    """
+    B3FS = 'B3FS'
+    r"""B3FS: 6 × 6-mm Surface-mounting Switches
+    """
+    B3S = 'B3S'
+    r"""B3S: Surface-mounting Switches with a Sealed Structure for High Reliability.
+    """
+    B3SL = 'B3SL'
+    r"""B3S: Surface-mounting Switches with a Sealed Structure
+    """
+    # C&K
+    KSC = 'KSC'
+    r"""KSC: Sealed Tact Switch for SMT. Hard and soft actuator.
+    """
+    KSx0A = 'KSx0A'
+    r"""KSx0A: KSA & KSL Series; Sealed Tact Switch
+    """
+    # Panasonic
+    EVPBF = 'EVPBF'
+    r"""EVPBF: 6mm Square Middle Travel. SMD Light Touch Switch. 
+    """
+    EVQP0 = 'EVQP0'
+    r"""EVQP0: 6 mm Square Thin Type SMD Light Touch Switches. 
+    """
+    EVQP2 = 'EVQP2'
+    r"""EVQP2: 4.7 mm × 3.5 mm SMD Light Touch Switches 
+    """
+    EVQPL = 'EVQPL'
+    r"""EVQPL: 4.9 mm Square SMD Light Touch Switches 
+    """
+    # Alps
+    SKOG = 'SKOG'
+    r"""SKOG: 5.2 mm Square Low-profile (Surface Mount Type)
+    """
+    SKRK = 'SKRK'
+    r"""SKRK: 3.9 × 2.9 mm Compact (Surface Mount Type)
+    """
+
+
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*   class cqMakerTactSwitch (PartBase, partParamsTactSwitches)             *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+
+class cqMakerTactSwitch (PartBase, partParamsTactSwitches):
+    r"""A class for creating a 3D models which parameter are defined in the class ``partsTactSwitches``
+    :param parameter: namedtuple containing the variable parameter for building the different 3D models.
+    :type  parameter: ``partsTactSwitches.Params``
+
+    """
+    
+    def __init__(self, parameter):
+        PartBase.__init__(self, parameter)
+        partParamsTactSwitches.__init__(self, parameter)
+        
+        # get all entries of the params list as dictionary
+        args = parameter._asdict()
+            
+        self.serie = parameter.serie                                                                                                # The component serie
+        self.destination_dir = parameter.destination_dir if parameter.destination_dir != None else  'Button_Switch_SMD.3dshapes' 
+        self.button_type = parameter.button_type if parameter.button_type != None else ButtonType.FLAT                              # Type of button from class ButtonType
+        self.with_gnd_pin = parameter.with_gnd_pin if parameter.with_gnd_pin != None else False                                     # boolean: True if Ground Terminal is present
+        self.cover_color_key = parameter.cover_color_key if parameter.cover_color_key != None else 'metal grey pins' 	            # Cover color
+        self.body_color_key = parameter.body_color_key if parameter.body_color_key != None else 'black body'	                    # Body colour
+        self.button_color_key = parameter.button_color_key if parameter.button_color_key != None else 'black body'                  # botton color
+        self.pin_color_key = parameter.pin_color_key if parameter.pin_color_key != None else 'metal grey pins'	                    # Pin color
+        self.gnd_pin_tip_to_center = parameter.gnd_pin_tip_to_center if parameter.gnd_pin_tip_to_center != None else 4.0            # pos of GND pin rel. to center of body, measured to tip of pin
+        self.no_gnd_pins = parameter.no_gnd_pins if parameter.no_gnd_pins != None else 1                                            # number of groung pins (1 or 2); default: 1                   
+        self.offset_gnd_pin = parameter.offset_gnd_pin if parameter.offset_gnd_pin != None else 0.0                                 # offset of ground pin to middle of housing; default: 0.0                            
+        self.gnd_pin_width = parameter.gnd_pin_width if parameter.gnd_pin_width != None else self.pin_width                                 # offset of ground pin to middle of housing; default: 0.0                            
+        
+        # Default parameter
+        self.cover_plate_with_pin_side_sheets = False
+        self.pin_gw_angle = 80.0        
+        self.edge_fillet = None     # if not None the outer edges of body and cover will be fillet
+        self.edge_chamfer = None    # if not None the outer edges of body and cover will be chamfer
+
+        # for SMD parts with a ground terminal an additional offset is necessary, because the center of the footprints is always in the center of all pins
+        # The offset will be set to None and must be defined within param function _paramsXXX
+        # TODO gnd_pin_tip_to_center is not the right dimension to be used for offset calculation. Check new algorithm with Parts having GW pin and GND Pin
+        if self.with_gnd_pin and self.terminal_shape == ShapeOfTerminal.GW:
+            self.offsets = None
+            #offsY = (self.gnd_pin_tip_to_center - self.pin_pitch / 2.0) / 2.0
+            #self.offsets = tuple(map(operator.add, self.offsets, (0.0, offsY, 0.0)))
+
+        # Call of function defining dimensions depending on the serie of terminals
+        paramFunction = self._serieSwitcher.get(self.serie, None)
+        if paramFunction == None:     # not a valid terminal_shape
+            FreeCAD.Console.PrintMessage(str(self.serie) + ' not a valid member of ' + str(TactSwitchSeries))
+            self.make_me = False
+        else:  # Call the funktion
+            paramFunction (self)
+        
+        
+    def _paramsForB3F (self):
+        r"""set the reqired dimensions for tactile switch serie Omron B3F
+
+        """
+        self.cover_plate_with_side_sheets = False
+        self.tht_pin_lower_clamp_angel = 25.0
+        self.tht_pin_clamp_extension = 0.5
+        self.edge_chamfer = 0.3
+
+
+    def _paramsForB3FS (self):
+        r"""set the reqired dimensions for tactile switch serie Omron B3FS
+
+        """
+        self.cover_plate_with_side_sheets = True
+        self.cover_side_pocket_width = self.pad_side_width = 2.0
+        # side pads and cover side clips
+        self.body_side_pads = self._padsSideCenter
+        self.cover_side_clips = self._coverSideSheetsClosed
+
+        self.button_proj_hight_bot = 0.5
+        self.button_proj_hight_top = 1.8
+        self.button_proj_hight_mid = self.button_height - self.button_proj_hight_bot - self.button_proj_hight_top
+        self.pin_bottom_length = 0.5
+
+
+    def _paramsForB3S (self):
+        r"""set the reqired dimensions for tactile switch serie Omron B3S
+
+        """
+        # for SMD parts with a ground terminal an additional offset is necessary, because the center of the footprints is always in the center of all pins
+        self.offsets = (0.0, 0.92, 0.0) if self.with_gnd_pin else (0.0, 0.0, 0.0)
+
+        self.cover_plate_with_side_sheets = True
+        self.cover_side_clips_bottom_width = 1.7
+        # side pads and cover side clips
+        self.body_side_pads = self._padsSideCenter
+        self.cover_side_clips = self._coverSideSheetsOpen
+
+
+    def _paramsForB3SL (self):
+        r"""set the reqired dimensions for tactile switch serie Omron B3SL
+
+        """
+        self.cover_plate_with_side_sheets = True
+        self.cover_side_pocket_width = self.pad_side_width = 3.0
+        # side pads and cover side clips
+        self.body_side_pads = self._padsSideCenter
+        self.cover_side_clips = self._coverSideSheetsClosed
+
+        # J-hook pins with no upper part
+        self.pin_top_length = 0.0
+        self.pin_top_radius = 0.0
+
+    def _paramsForB3U1 (self):
+        r"""set the reqired dimensions for tactile switch serie B3U-1x from Omron
+
+        """
+        # for SMD parts with a ground terminal an additional offset is necessary, because the center of the footprints is always in the center of all pins
+        self.offsets = (0.0, 0.82, 0.0) if self.with_gnd_pin else (0.0, 0.0, 0.0)
+        
+        self.cover_plate_with_side_sheets = True # cover side sheet has T-shape, plate height and pad size has to be defined 
+        self.cover_side_height =  0.9
+        self.pad_side_height = 0.55
+        self.pad_side_width = 0.3
+
+        self.pin_pocket_edge_length =  self.cover_thickness
+        self.pin_pocket_edge_width =  self.cover_thickness
+
+        # new cover thickness requires new calculation of body_height_plastic and pad_side_length   
+        self.cover_thickness = 0.15   
+        self.body_height_plastic = self.body_height - self.cover_thickness
+        self.pad_side_length =  self.cover_thickness 
+                
+        self.pin_bottom_length = 0.8
+
+        self.body_board_distance = 0.0
+        # make special pads and cover clips
+        self.body_side_pads = self._padSideEdge
+        self.cover_side_clips = self._coverSideSheets_T_Shape
+        
+
+    def _paramsForKSC (self):
+        r"""set the reqired dimensions for tactile switch serie C&K KSC7
+
+        """
+        self.cover_plate_with_side_sheets = True
+        self.cover_side_pocket_width = self.pad_side_width = 4.1
+
+        # button has a plate below cover
+        self.button_has_base_plate = True;
+        self.button_base_height = self.body_height * 0.3
+        self.body_height_plastic -= self.button_base_height
+        self.pad_side_height -= self.button_base_height
+
+        # side pads and cover side clips
+        self.body_side_pads = self._padsSideCenter
+        self.cover_side_clips = self._coverSideSheetsClosed
+
+        self.body_board_distance = 0.1
+
+
+    def _paramsForEVPBF (self):
+        r"""set the reqired dimensions for tactile switch serie Panasonic EVPBF
+
+        """
+        self.cover_plate_with_side_sheets = True # cover side sheet has T-shape, plate height and pad size has to be defined 
+        self.cover_side_height = 1.8
+        self.pad_side_height = 0.6
+        self.pad_side_width = 1.2 
+        
+        self.cover_plate_with_pin_side_sheets = True
+        self.cover_pin_side_sheet_width = self.pin_pitch - self.pin_width
+        self.cover_pin_side_sheet_height = 0.8
+        
+        self.button_hole_dia = 3.7
+        
+        # button has a plate below cover
+        self.button_has_base_plate = True;
+        self.button_base_height = self.cover_pin_side_sheet_height - self.cover_thickness
+        self.body_height_plastic -= self.button_base_height
+
+        # J-hook pins with no upper part
+        self.pin_top_length = 0.0
+        self.pin_top_radius = 0.0
+
+        self.body_board_distance = 0.0
+        # make special pads and cover clips
+        self.body_side_pads = self._padSideEdge
+        self.cover_side_clips = self._coverSideSheets_T_Shape
+        
+    def _paramsForEVQP0 (self):
+        r"""set the reqired dimensions for tactile switch serie Panasonic EVPQP0
+
+        """
+        self.cover_plate_with_side_sheets = True # cover side sheet has T-shape, plate height and pad size has to be defined 
+        self.cover_side_height = 1.25
+        self.pad_side_height = 0.5
+        self.pad_side_width = 1.2 
+       
+        self.cover_plate_with_pin_side_sheets = True
+        self.cover_pin_side_sheet_width = self.pin_pitch - self.pin_width
+        self.cover_pin_side_sheet_height = 0.5
+        
+        self.button_hole_dia = 2.5
+        
+        # J-hook pins with no upper part
+        self.pin_top_length = 0.0
+        self.pin_top_radius = 0.0
+
+        self.body_board_distance = 0.0
+        # make special pads and cover clips
+        self.body_side_pads = self._padSideEdge
+        self.cover_side_clips = self._coverSideSheets_T_Shape
+
+        
+    def _paramsForEVQP2 (self):
+        r"""set the reqired dimensions for tactile switch serie Panasonic EVPQP0
+
+        """
+        self.cover_plate_with_side_sheets = True # cover side sheet has T-shape, plate height and pad size has to be defined 
+        self.cover_side_height = 1.2
+        self.pad_side_height = 0.65
+        self.pad_side_width = 0.65 
+       
+        self.cover_plate_with_pin_side_sheets = True
+        self.cover_pin_side_sheet_width = (self.pin_pitch - self.pin_width) * 0.9
+        self.cover_pin_side_sheet_height = 0.8
+        
+        self.button_hole_dia = 2.2
+        
+        # J-hook pins with no upper part
+        self.pin_top_length = 0.0
+        self.pin_top_radius = 0.0
+
+        self.pin_pocket_edge_length =  1.2
+        self.pin_height = 0.6
+
+        self.body_board_distance = 0.0
+        # make special pads and cover clips
+        self.body_side_pads = self._padSideEdge
+        self.cover_side_clips = self._coverSideSheets_T_Shape
+        
+        
+    def _paramsForEVQPL (self):
+        r"""set the reqired dimensions for tactile switch serie Panasonic EVPQP0
+
+        """
+        self.cover_plate_with_side_sheets = True # cover side sheet has T-shape, plate height and pad size has to be defined 
+        self.cover_side_height = 0.45
+        self.cover_solid_side_width = 2.5
+       
+        self.cover_plate_with_pin_side_sheets = True
+        self.cover_pin_side_sheet_width = 1.2
+        self.cover_pin_side_sheet_height = 0.6
+        
+        self.button_hole_dia = 3.2
+        
+        # J-hook pins with no upper part
+        self.pin_top_length = 0.0
+        self.pin_top_radius = 0.0
+        self.pin_height = self.body_height / 2.0
+
+        self.body_board_distance = 0.0
+        # make special pads and cover clips
+        self.body_side_pads = None
+        self.cover_side_clips = self._coverSideSheetsSolid
+
+        self.rotation = 0.0
+
+    def _paramsForKSx0A (self):
+        r"""set the reqired dimensions for tactile switch serie Panasonic EVPQP0
+
+        """
+        self.cover_plate_with_side_sheets = True # cover side sheet has T-shape, plate height and pad size has to be defined 
+        self.cover_side_height =2.2
+               
+        self.button_hole_dia = 3.2
+        
+        self.body_board_distance = 0.0
+
+        self.tht_pin_lower_clamp_angel = 25.0
+        self.tht_pin_clamp_extension = 0.5
+
+        self.cover_plate_with_pin_side_sheets = True
+        self.cover_pin_side_sheet_width = 3.0
+        self.cover_pin_side_sheet_height = 2.0 * self.cover_thickness
+
+        # make special pads and cover clips
+        self.cover_side_clips_bottom_width = 2.0
+        self.cover_side_pocket_width = self.pad_side_width =4.6
+        
+        self.button_has_base_plate = True;
+        self.button_base_height = self.body_height * 0.3
+        self.body_height_plastic -= self.button_base_height
+        self.pad_side_height -= self.button_base_height
+
+        # side pads and cover side clips
+        self.body_side_pads = self._padsSideCenter
+        self.cover_side_clips = self._coverSideSheetsOpen
+
+    def _paramsForSKOG (self):
+        r"""set the reqired dimensions for tactile switch serie Panasonic EVPQP0
+
+        """
+        self.cover_plate_with_side_sheets = True # cover side sheet has T-shape, plate height and pad size has to be defined 
+        self.cover_side_height = 0.4
+        self.cover_solid_side_width = 2.4
+       
+        self.cover_plate_with_pin_side_sheets = True
+        self.cover_pin_side_sheet_width = 2.4
+        self.cover_pin_side_sheet_height = 0.4
+
+        self.body_width -= 2.0 * self.cover_thickness
+
+        self.pin_height = 0.25
+        
+        self.button_hole_dia = 2.1
+
+        self.edge_chamfer = 1.2
+        self.pin_bottom_length = 0.6
+        self.pin_gw_angle = 60.0
+        
+        self.body_board_distance = 0.0
+        # make special pads and cover clips
+        self.body_side_pads = None
+        self.cover_side_clips = self._coverSideSheetsSolid
+        
+
+    def _paramsForSKRK (self):
+        r"""set the reqired dimensions for tactile switch serie SKRK from E-Switch
+
+        """
+        # for SMD parts with a ground terminal an additional offset is necessary, because the center of the footprints is always in the center of all pins
+        self.offsets = (0.0, 0.82, 0.0) if self.with_gnd_pin else (0.0, 0.0, 0.0)
+        
+        self.cover_plate_with_side_sheets = True # cover side sheet has T-shape, plate height and pad size has to be defined 
+        self.cover_side_height =  1.2
+        self.pad_side_height = 0.7
+        self.pad_side_width = 0.5
+
+        self.pin_pocket_edge_length =  self.cover_thickness
+        self.pin_pocket_edge_width =  self.cover_thickness
+
+        self.cover_plate_with_pin_side_sheets = True
+        self.cover_pin_side_sheet_width = 0.5
+        self.cover_pin_side_sheet_height = 0.7
+
+        # new cover thickness requires new calculation of body_height_plastic and pad_side_length   
+        self.cover_thickness = 0.15   
+        self.body_height_plastic = self.body_height - self.cover_thickness
+        self.pad_side_length =  self.cover_thickness 
+                
+        self.pin_bottom_length = 0.8
+
+        self.body_board_distance = 0.0
+        # make special pads and cover clips
+        self.body_side_pads = self._padSideEdge
+        self.cover_side_clips = self._coverSideSheets_T_Shape
+        
+
+    _serieSwitcher = {
+        TactSwitchSeries.B3F:       _paramsForB3F,
+        TactSwitchSeries.B3FS:      _paramsForB3FS,
+        TactSwitchSeries.B3S:       _paramsForB3S, 
+        TactSwitchSeries.B3SL:      _paramsForB3SL,
+        TactSwitchSeries.B3U1:      _paramsForB3U1,
+        TactSwitchSeries.KSC:       _paramsForKSC,
+        TactSwitchSeries.KSx0A:     _paramsForKSx0A,
+        TactSwitchSeries.EVPBF:     _paramsForEVPBF,
+        TactSwitchSeries.EVQP0:     _paramsForEVQP0,
+        TactSwitchSeries.EVQP2:     _paramsForEVQP2,
+        TactSwitchSeries.EVQPL:     _paramsForEVQPL,
+        TactSwitchSeries.SKOG:      _paramsForSKOG,
+        TactSwitchSeries.SKRK:      _paramsForSKRK,
+
+        }
+
+
+
+    def get_dest_3D_dir(self):
+        r"""get the destination directory for the 3D model export
+
+        :rtype: string
+        """
+        return self.destination_dir
+
+    def _padsSideCenter (self):
+        r"""generates a body to be placed (central) at the top side of the parts body. These side pads are the fixing elements for the cover clips.
+
+        :rtype: ``solid``
+        """
+        pad = cq.Workplane("XY", origin=((self.body_length - self.pad_side_length) / 2.0, 0.0, self.body_height_plastic - self.pad_side_height))\
+                    .rect(self.pad_side_length, self.pad_side_width).extrude(self.pad_side_height)
+
+        return pad.union(pad.mirror("YZ"))
+
+    def _padSideEdge (self):
+        r"""generates a body to be placed (left and right) at the side of the parts body. These side pads are the fixing elements for the cover clips (upside down T-shape).
+
+        :rtype: ``solid``
+        """
+        pad = cq.Workplane("XY",  origin=((self.body_length - self.pad_side_length) / 2.0, (self.body_width - self.pad_side_width) / 2.0))\
+            .workplane(offset=self.body_height_plastic - self.pad_side_height)\
+            .rect(self.pad_side_length, self.pad_side_width).extrude(self.pad_side_height)\
+            .edges(">Z").edges(">X").fillet(self.cover_thickness*0.99)
+        pad = pad.union(pad.mirror("XZ"))
+        return pad.union(pad.mirror("YZ"))
+
+    def __pocketEdgePinBottom (self):
+        r"""generates a body used to cut deepenings at the bottom of the parts body, where the pins are placed.
+
+        :rtype: ``solid``
+        """
+        body_length_without_pads = self.body_length - 2.0 * self.pad_side_length
+        return cq.Workplane("XY")\
+                 .rect((body_length_without_pads - self.pin_pocket_edge_length), (self.body_width - self.pin_pocket_edge_width), forConstruction=True) \
+                 .vertices().rect(self.pin_pocket_edge_length, self.pin_pocket_edge_width).extrude(self.bottom_pocket_depth)
+            
+    def _mountingPads (self, pos, r=0.65):
+        r"""generates a four cylinders placed at the top of the parts body to fix the cover sheet for covers not having side clips.
+
+        :rtype: ``solid``
+        """
+        pad = cq.Workplane("XY").workplane(offset=self.body_height_plastic).circle(r)\
+                .extrude(2.0 * self.cover_thickness).edges(">Z").fillet(0.05)\
+                .translate((pos[0], pos[1], 0.0))
+
+        pad = pad.union(pad.mirror("YZ"))
+                
+        return pad.union(pad.mirror("XZ"))
+    
+    def _pegs(self):
+        r"""generates one or more cylinders to be placed as reference pegs at the bottom of the parts body.
+
+        :rtype: ``solid``
+        """
+        peg = cq.Workplane("XY").circle(self.pegs_radius)\
+                .extrude(-self.pegs_heigth).edges("<Z").chamfer(self.pegs_radius*0.3)
+
+        peg = peg.translate((self.pegs_pitch / 2.0, 0.0, 0.0))
+        peg = peg.union(peg.mirror("YZ"))
+
+        return peg
+
+
+    def makePlasticCase (self):
+        """ create the plastic body of the tactile switch
+        :rtype: ``solid``
+        """
+        body = cq.Workplane("XY")
+        if self.cover_plate_with_side_sheets:
+            body_length_without_pads = self.body_length - 2.0 * self.pad_side_length
+            body = body.rect(body_length_without_pads, self.body_width).extrude(self.body_height_plastic)
+
+
+            if self.body_side_pads is not None:
+                body = body.union(self.body_side_pads())
+
+            # edgeFilter = '<({0:5.2f}, 0.0, 0.0)'.format(-(self.body_length/2.0-0.1))
+
+
+        else: 
+            body = body.rect(self.body_length, self.body_width).extrude(self.body_height_plastic)
+                        
+            body = body.union(self._mountingPads((self.body_length / 2.0 * 0.7, self.body_width / 2.0 * 0.7), self.body_length * 0.1))
+
+
+        if self.edge_fillet is not None:
+            body = body.edges("|Z").fillet(self.edge_fillet)
+
+        if self.edge_chamfer is not None:
+            body = body.edges("|Z").chamfer(self.edge_chamfer)
+
+        body = body.cut(self.__pocketEdgePinBottom())
+
+        if self.has_pegs:
+            body = body.union(self._pegs())
+
+        return body
+
+
+
+    
+    def _coverSideSheetsClosed (self):
+        r"""generates a body used as a side clip of the top cover sheet. The shape of the side clip is a closed frame.
+        The side clips will be placed at the sides where are no pins.
+
+        :rtype: ``solid``
+        """
+        body_length_without_pads = self.body_length - 2.0 * self.pad_side_length
+        body = Polyline(cq.Workplane("YZ").workplane(offset=body_length_without_pads / 2.0))\
+            .addMoveTo(-self.cover_side_pocket_width / 2.0, self.body_height)\
+            .addPoint(-(self.body_width - self.cover_side_pocket_width) / 2.0, 0.0)\
+            .addPoint(0.0, -self.cover_side_height)\
+            .addPoint(self.body_width, 0.0)\
+            .addPoint(0.0, self.cover_side_height)\
+            .addPoint(-(self.body_width - self.cover_side_pocket_width) / 2.0, 0.0)\
+            .addPoint(0.0, -(self.cover_side_pocket_heigth + self.cover_thickness))\
+            .addPoint(-self.cover_side_pocket_width, 0.0)\
+            .make().extrude(self.cover_thickness).edges(">Z").edges(">X").fillet(self.cover_thickness*0.99)
+
+        #body = body.edges("|Z").fillet(0.05)
+        body = body.edges("<Z").fillet(0.05)
+
+        body = body.union(body.mirror("YZ"))
+
+        return body
+
+    def _coverSideSheetsOpen (self):
+        r"""generates a body used as a side clip of the top cover sheet. The shape of the side clip is a frame, open at the bottom.
+        The side clips will be placed at the sides where are no pins.
+
+        :rtype: ``solid``
+        """
+        body_length_without_pads = self.body_length - 2.0 * self.pad_side_length
+        body = Polyline(cq.Workplane("YZ").workplane(offset=body_length_without_pads / 2.0))\
+            .addMoveTo(-self.cover_side_pocket_width / 2.0, self.body_height)\
+            .addPoint(-(self.body_width - self.cover_side_pocket_width) / 2.0, 0.0)\
+            .addPoint(0.0, -self.cover_side_height)\
+            .addPoint(self.cover_side_clips_bottom_width, 0.0)\
+            .addPoint(0.0, self.cover_side_height - self.cover_side_pocket_heigth - self.cover_thickness)\
+            .addPoint(-self.cover_side_clips_bottom_width + (self.body_width - self.cover_side_pocket_width) / 2.0, 0.0)\
+            .make().extrude(self.cover_thickness).edges(">Z").edges(">X").fillet(self.cover_thickness*0.99)
+
+        #body = body.edges("|Z").fillet(0.05)
+        body = body.edges("<Z").fillet(0.05)
+
+        body = body.union(body.mirror("XZ"))
+        body = body.union(body.mirror("YZ"))
+
+        return body
+
+    def _coverSideSheets_T_Shape (self):
+        r"""generates a body used as a side clip of the top cover sheet. The shape of the side clip is like an upside down T.
+        The side clips will be placed at the sides where are no pins.
+
+        :rtype: ``solid``
+        """
+        body_length_without_pads = self.body_length - 2.0 * self.pad_side_length
+        h = self.body_height -self.body_height_plastic + self.pad_side_height
+        body = Polyline(cq.Workplane("YZ").workplane(offset=body_length_without_pads / 2.0))\
+            .addMoveTo(0.0, self.body_height)\
+            .addPoint(-(self.body_width / 2.0 - self.pad_side_width), 0.0)\
+            .addPoint(0.0, -h)\
+            .addPoint(-self.pad_side_width / 2.0, 0.0)\
+            .addPoint(0.0, -(self.cover_side_height  - h))\
+            .addPoint(self.pad_side_width, 0.0)\
+            .addPoint(0.0, (self.cover_side_height  - h) * 1.5)\
+            .addPoint((self.body_width - 3.0 * self.pad_side_width) / 2.0, 0.0)\
+            .addMirror().make().extrude(self.cover_thickness).edges(">Z").edges(">X").fillet(self.cover_thickness*0.99)\
+
+        #body = body.edges("|Z").fillet(0.05)
+        body = body.edges("<Z").fillet(0.05)
+
+        body = body.union(body.mirror("XZ"))
+        body = body.union(body.mirror("YZ"))
+
+        return body
+
+
+    def _coverSideSheetsSolid (self):
+        r"""generates a body used as a side clip of the top cover sheet. The shape of the side clip is a rectangle.
+        The side clips will be placed at the sides where are no pins.
+
+        :rtype: ``solid``
+        """
+        body_length_without_pads = self.body_length - 2.0 * self.pad_side_length
+        body = cq.Workplane("YZ").workplane(offset=body_length_without_pads / 2.0)\
+            .box(self.cover_solid_side_width, self.cover_side_height, self.cover_thickness)\
+            .edges(">Z").edges(">X").fillet(self.cover_thickness*0.99)\
+            .translate((self.cover_thickness / 2.0, 0.0, self.body_height - self.cover_side_height / 2.0))
+
+        body = body.union(body.mirror("YZ"))
+
+        return body
+
+    def __coverPinSideSheets (self):
+        r"""generates a body used as a side clip of the top cover sheet. The shape of the side clip is a rectangle.
+        The side clips will be placed at the sides where the pins are.
+
+        :rtype: ``solid``
+        """
+        body = cq.Workplane("XZ").box(self.cover_pin_side_sheet_width, self.cover_pin_side_sheet_height, self.cover_thickness)\
+                .translate ((0.0, (self.body_width + self.cover_thickness)/2.0, \
+                    self.body_height - (self.cover_pin_side_sheet_height) / 2.0))\
+                .edges(">Z").edges(">Y").fillet(self.cover_thickness*0.99).edges(">Y").fillet(0.05)
+
+        return body.union(body.mirror("XZ"))
+
+    def _buttonRingRound (self):
+        r"""generates a cylindric body used as a guide ring of the push button, placed on top of the cover sheet.
+
+        :rtype: ``solid``
+        """
+        body = cq.Workplane("XY").workplane(offset=self.cover_thickness)\
+                    .circle(self.button_ring_radius)\
+                    .extrude(self.button_ring_heigth).edges(">Z").edges("%CIRCLE").fillet(0.25)
+
+        return body
+
+    def _buttonRingOctagon (self):
+        r"""generates a octagone body used as a guide element of the push button, placed on top of the cover sheet.
+
+        :rtype: ``solid``
+        """
+        body = cq.Workplane("XY").workplane(offset=self.cover_thickness)\
+                    .rect(self.button_ring_length, self.button_ring_width)\
+                    .extrude(self.button_ring_heigth)\
+                    .edges("|Z").chamfer(self.button_ring_width*0.2).edges("|Z").fillet(self.button_ring_width*0.1)
+                    #.edges(">Z").edges("%CIRCLE").fillet(0.25)
+
+        return body
+
+
+    def _makeGndPin (self):
+        r"""generates a pin connected to the top metallic cover sheet used as a ground pin.
+
+        :rtype: ``solid``
+        """
+        if self.terminal_shape.startswith ('TH'):
+            # we must change pin thickness, but need to change it back
+            pt = self.cover_thickness  # new pin thickness
+
+            # change values
+            pt, self.pin_thickness = self.pin_thickness, pt
+            self.gnd_pin_width, self.pin_width = self.pin_width, self.gnd_pin_width
+                
+            # the gnd pin is connected to cover, thus the length must be:
+            pl = self.body_height - self.cover_thickness + self.pin_length_below_body + \
+                    self.cover_thickness + self.body_board_distance
+
+            top_length = self.gnd_pin_tip_to_center - self.body_length / 2.0 
+            gndPin = self._make_angled_pin (pl, top_length, 0.0, 'THT')\
+                .rotate ((0,0,0), (1,0,0), -90.0)\
+                .rotate ((0,0,0), (0,0,1), -90.0)\
+                .translate ((-self.body_length/2.0 + self.cover_thickness , 0.0, self.body_height - self.cover_thickness + self.pin_thickness / 2.0))
+
+            # change back
+            pt, self.pin_thickness = self.pin_thickness, pt
+            self.gnd_pin_width, self.pin_width = self.pin_width, self.gnd_pin_width
+
+        elif self.terminal_shape is ShapeOfTerminal.GW:
+            # we must change some pin dimensions, but need to change them back
+            # the gnd pin is connected to cover at position (body_width / 2.0), thus the length must be:
+            pl = self.gnd_pin_tip_to_center - self.body_length / 2.0 + self.cover_thickness # (self.pin_bottom_length 
+            pt = self.cover_thickness  # new pin thickness
+
+            # change values
+            pl, self.pin_length = self.pin_length, pl
+            pt, self.pin_thickness = self.pin_thickness, pt
+            self.gnd_pin_width, self.pin_width = self.pin_width, self.gnd_pin_width
+
+            # check if bottom length fits to overall GW pin length, if not we must shorten bottom length
+            bl = min (self.pin_bottom_length, self.pin_length - 2.0 * self.pin_thickness) # 1 x thickness + 2 x radius (1/2 thickness)
+            ri = self.pin_thickness / 2.0
+            gndPin = self._make_gullwing_pin (self.body_height - self.cover_thickness + self.body_board_distance, bl, ri, ri)\
+                .rotate ((0,0,0), (0,0,1), 90.0).translate ((-self.body_length / 2.0 + self.cover_thickness, 0.0,  -self.body_board_distance))
+
+            # change back
+            pl, self.pin_length = self.pin_length, pl
+            pt, self.pin_thickness = self.pin_thickness, pt
+            self.gnd_pin_width, self.pin_width = self.pin_width, self.gnd_pin_width
+
+        else:
+            # we must change some pin dimensions, but need to change them back
+            # the gnd pin is connected to cover at position (body_width / 2.0), thus the length must be:
+            pt = self.cover_thickness  # new pin thickness
+
+            # change values
+            pt, self.pin_thickness = self.pin_thickness, pt
+            self.gnd_pin_width, self.pin_width = self.pin_width, self.gnd_pin_width
+
+            top_len = self.gnd_pin_tip_to_center - self.body_length / 2.0 
+            gndPin = self._make_Jhook_pin (self.body_height - self.cover_thickness + self.body_board_distance, self.pin_bottom_length/2.0, top_len, 0.01, 0.01)\
+                .rotate ((0,0,0), (0,0,1), 90.0).translate ((-(self.gnd_pin_tip_to_center - self.pin_thickness), -self.offset_gnd_pin,  -self.body_board_distance))
+
+            # change back
+            pt, self.pin_thickness = self.pin_thickness, pt
+            self.gnd_pin_width, self.pin_width = self.pin_width, self.gnd_pin_width
+
+        if self.no_gnd_pins == 2:
+            gndPin = gndPin.union(gndPin.rotate((0,0,0), (0,0,1), 180.0))
+
+        return gndPin
+
+
+    def _coverCentralHole(self):
+        """ create a body to cut the central hole for the button into cover
+        :rtype: ``solid``
+        """
+        # even if button ring does not exist, we can extend the height of the cutting cylinder up to cover_thickness+button_ring_heigth
+        body = cq.Workplane("XY").circle(self.button_hole_dia / 2.0).extrude(self.cover_thickness + self.button_ring_heigth)
+        return body
+
+
+    def _coverFilletCentralHole(self, body):
+        """ fillet edges of central circular hole in cover
+        :param body: The body with hole to fillet 
+        :type body: ``solid``
+        :rtype: ``solid``
+        """
+        return body.edges("%CIRCLE").fillet(self.cover_thickness*0.25)
+
+    def makeCoverPlate (self):
+        """ create the outer metallic frame of switch
+        :rtype: ``solid``
+        """
+        if self.cover_plate_with_side_sheets:
+            body_length_without_pads = self.body_length - 2.0 * self.pad_side_length
+        else:
+            body_length_without_pads = self.body_length
+        
+        body = cq.Workplane("XY")\
+                    .rect(body_length_without_pads, self.body_width)\
+                    .extrude(self.cover_thickness)
+
+        if self.edge_fillet is not None:
+            body = body.edges("|Z").fillet(self.edge_fillet)
+
+        if self.edge_chamfer is not None:
+            body = body.edges("|Z").chamfer(self.edge_chamfer)
+
+
+        if self.button_ring is not ButtonRing.NONE:
+            if self.button_ring is ButtonRing.ROUND:
+                body = body.union(self._buttonRingRound())
+            elif self.button_ring is ButtonRing.OCTA:
+                body = body.union(self._buttonRingOctagon())
+        
+        body = body.cut(self._coverCentralHole())
+        body = self._coverFilletCentralHole(body)
+
+        body = body.translate((0.0, 0.0, self.body_height - self.cover_thickness))
+
+        if self.cover_plate_with_side_sheets:
+            body = body.union(self.cover_side_clips())
+
+        if self.cover_plate_with_pin_side_sheets:
+            body = body.union(self.__coverPinSideSheets())\
+
+        if self.with_gnd_pin:
+            body = body.union(self._makeGndPin())
+            #body = (self._makeGndPin())
+
+        return body
+
+    def _buttonBasePlate (self):
+        """ For some tactile switches the round button has a rectangluar base plate placed below the top metallic cover.
+      
+        Create a body to be used as a base plate of the button.
+        :rtype: ``solid``
+        """
+        if self.cover_plate_with_side_sheets:
+            body_length_without_pads = self.body_length - 2.0 * self.pad_side_length
+        else:
+            body_length_without_pads = self.body_length
+            
+        body = cq.Workplane("XY").workplane(offset=self.body_height - self.cover_thickness)\
+            .rect(body_length_without_pads + 0.01, self.body_width + 0.01).extrude(-self.button_base_height)\
+            .edges("|Z").fillet(0.5)
+
+        return body
+
+
+    def makeButton (self):
+        """ create the button of switch, depending on button type
+        :rtype: ``solid``
+        """
+        h = self.button_height if self.button_type == ButtonType.FLAT else self.button_proj_hight_bot
+            
+        body = cq.Workplane("XY")\
+            .workplane(offset=self.body_height - self.cover_thickness).circle(self.button_dia/2.0).extrude(h)
+            
+        if h > 0.1:
+            body = body.edges(">Z").edges("%CIRCLE").fillet(0.1)
+
+        if self.button_has_base_plate:
+            body = body.union(self._buttonBasePlate())
+
+        if self.button_type == ButtonType.PROJ:
+            proj = cq.Workplane("XY").workplane(offset=self.body_height - self.cover_thickness + h)\
+                .rect(self.button_proj_length_mid, self.button_proj_length_mid).extrude(self.button_proj_hight_mid)\
+                .edges("|Z").fillet(0.05)
+            body = body.union(proj)
+            proj = cq.Workplane("XY").workplane(offset=self.body_height - self.cover_thickness + h + self.button_proj_hight_mid)\
+                .rect(self.button_proj_length_top, self.button_proj_length_top)\
+                .circle(self.button_proj_length_top/3.5)\
+                .extrude(self.button_proj_hight_top)\
+                .edges("|Z").fillet(0.2).edges(">Z").edges("|X").fillet(0.2)#.edges(">Z").edges("|Y").fillet(0.2)
+            body = body.union(proj)
+
+
+        return body
+
+
+    def _duplicatePins (self, onePin, noPins=None, pitch=None):
+        r"""Duplicates all pins from first pin.
+
+        :param onePin: The first pin of the model
+        :type  onePin: ``solid``
+
+        :param codeFormat:
+        :type  codeFormat: ``CodeFormat`` default: ``CodeFormat.REAL``
+        :return: all pins
+        :rtype: ``solid``
+        """
+
+        if noPins is None:
+            noPins = self.num_pins
+        
+        if pitch is None:
+            pitch = self.pin_pitch
+
+        m = noPins // 2
+        pins = [onePin]       
+        for i in range (1, noPins):
+            nextPin = (onePin.translate((-pitch * (i % m), 0, 0)))
+            nextPin = nextPin.rotate ((0,0,0), (0,0,1), 180.0 * (i // m))
+            pins.append(nextPin)
+        return self._union_all(pins)
+
+    def _makeGwPin (self):
+        """ create a gullwing pin
+        :rtype: ``solid``
+        """
+        return self._make_angular_gullwing_pin (self.pin_height, self.pin_bottom_length, self.pin_gw_angle)
+
+    def _makeJhPin (self):
+        """ create a J-hook pin
+        :rtype: ``solid``
+        """
+        return self._make_Jhook_pin (self.pin_height, self.pin_bottom_length, self.pin_top_length,  self.pin_top_radius)
+
+    def _makeThPin (self):
+        """ create a straight THT pin
+        :rtype: ``solid``
+        """
+        return self._make_angled_pin (self.pin_height, self.pin_top_length)\
+            .rotate ((0,0,0), (1,0,0), -90.0)\
+            .translate ((0.0, 0.0, self.pin_z_shift))
+
+    def _makeThcPin (self):
+        """ create a unsymmetrically bended THT pin
+        :rtype: ``solid``
+        """
+        return self._make_angled_clamping_pin (self.pin_height, self.pin_top_length, self.tht_pin_clamp_extension, self.tht_pin_lower_clamp_angel )\
+            .rotate ((0,0,0), (1,0,0), -90.0)\
+            .translate ((0.0, 0.0, self.pin_z_shift))
+
+    def _makeThlPin (self):
+        """ create a symmetrically bended (lambda shape) THT pin
+        :rtype: ``solid``
+        """
+        return self._make_angled_lambda_pin (self.pin_height, self.pin_top_length, self.tht_pin_clamp_extension)\
+            .rotate ((0,0,0), (1,0,0), -90.0)\
+            .translate ((0.0, 0.0, self.pin_z_shift))
+
+    _pinStyleSwitcher = {
+        ShapeOfTerminal.GW: _makeGwPin,
+        ShapeOfTerminal.JH: _makeJhPin,
+        ShapeOfTerminal.TH: _makeThPin,
+        ShapeOfTerminal.THC: _makeThcPin,
+        ShapeOfTerminal.THL: _makeThlPin,
+        }
+
+
+    def make_pins(self):
+        r"""Creates all pins of the tactile switch, depending on the ``terminal_shape`` defined in ``parameter``.
+        :rtype: ``solid`` of all pins
+        """
+        # get the function from switcher dictionary making the pin defined by the terminal_shape key
+        firstPin = self._pinStyleSwitcher.get(self.terminal_shape)(self)
+        allPins = self._duplicatePins (firstPin.translate(self.first_pin_pos))
+        
+
+        return (allPins)
+
+
+    def make_3D_model(self):
+        """ create a 3D model of a tactile switch. Four parts will be created: plastic body, metallic cover, button, pins.
+
+        This function will be called from the main_generator script.
+        :return: list of the materials used for the 3D model
+        :rtype: ``dictionary`` 
+        """
+        destination_dir = self.get_dest_3D_dir()
+        
+        # all parts belonging to parts body must be shifted by body_board_distance 
+        case = self.makePlasticCase().translate((0.0, 0.0, self.body_board_distance))
+        cover = self.makeCoverPlate ().translate((0.0, 0.0, self.body_board_distance))
+        button = self.makeButton ().translate((0.0, 0.0, self.body_board_distance))
+        pins = self.make_pins()
+        show(case)
+        show(cover)
+        show(button)
+        show(pins)
+     
+        doc = FreeCAD.ActiveDocument
+        objs = GetListOfObjects(FreeCAD, doc)
+
+     
+        body_color = shaderColors.named_colors[self.body_color_key].getDiffuseFloat()
+        cover_color = shaderColors.named_colors[self.cover_color_key].getDiffuseFloat()
+        button_color = shaderColors.named_colors[self.button_color_key].getDiffuseFloat()
+        pin_color = shaderColors.named_colors[self.pin_color_key].getDiffuseFloat()
+
+        # must be the same order of the above show(..) calls
+        Color_Objects(Gui, objs[0], body_color)
+        Color_Objects(Gui, objs[1], cover_color)
+        Color_Objects(Gui, objs[2], button_color)
+        Color_Objects(Gui, objs[3], pin_color)
+
+        col_body = Gui.ActiveDocument.getObject(objs[0].Name).DiffuseColor[0]
+        col_cover = Gui.ActiveDocument.getObject(objs[1].Name).DiffuseColor[0]
+        col_button = Gui.ActiveDocument.getObject(objs[2].Name).DiffuseColor[0]
+        col_pin = Gui.ActiveDocument.getObject(objs[3].Name).DiffuseColor[0]
+        
+        material_substitutions={
+            col_body[:-1]:self.body_color_key,
+            col_cover[:-1]:self.cover_color_key,
+            col_button[:-1]:self.button_color_key,
+            col_pin[:-1]:self.pin_color_key,
+        }
+        
+        expVRML.say(material_substitutions)
+
+        # fuse all parts of model
+        while len(objs) > 1:
+                FuseObjs_wColors(FreeCAD, FreeCADGui, doc.Name, objs[0].Name, objs[1].Name)
+                del objs
+                objs = GetListOfObjects(FreeCAD, doc)
+
+        #rotate if required
+        if (self.rotation != 0):
+            z_RotateObject(doc, self.rotation)
+
+        s = objs[0].Shape
+        shape = s.copy()
+        shape.Placement = s.Placement;
+        shape.translate(self.offsets)
+        objs[0].Placement = shape.Placement
+
+        return material_substitutions
+
+    
+    
+
+#*                                                                          *
+#*                                                                          *
+#*     class partsTactSwitches                                              *
+#*                                                                          *
+#*                                                                          *
+class partsTactSwitches ():
+    r"""A class for defining parameter of a special tactile switch. 
+
+    """
+
+    def model_exist(self, modelName):
+        r"""checks if the model with given name exists. i.e. is part of ``all_params``
+        
+        :param modelName: name of the model as defined in ``all_params``
+        :type modelName: ``string``
+        :return: True if model exists, otherwise False
+        :rtype: ``boolean``
+        """
+        for n in self.all_params:
+            if n == modelName:
+                return True
+                
+        return False
+        
+        
+    def get_param_list_all(self):
+        r"""returns a list of all model variants defined in `all_params``
+        
+        :rtype: ``list``
+        """
+        list = []
+        for n in self.all_params:
+            list.append(n)
+        
+        return list
+
+
+    def getModelVariant (self, modelName):
+        r"""returns the parameter namedtuple from ``all_params`` for the given model name
+        
+        :param modelName: name of the model as defined in ``all_params``
+        :type modelName: ``string``
+        :rtype: ``namedtuple``
+        """
+        return cqMakerTactSwitch (self.all_params[modelName]) 
+
+    ##enabling optional/default values to None
+    def namedtuple_with_defaults(typename, field_names, default_values=()):
+
+        T = collections.namedtuple(typename, field_names)
+        T.__new__.__defaults__ = (None,) * len(T._fields)
+        if isinstance(default_values, collections.Mapping):
+            prototype = T(**default_values)
+        else:
+            prototype = T(*default_values)
+        T.__new__.__defaults__ = tuple(prototype)
+        return T
+        
+    Params = namedtuple_with_defaults("Params", [
+        'modelName',		        # modelName, must correspond to 3D file name defined in KiCad footprint
+        'body_width',		        # Body width, default: 6.0
+        'body_length',		        # Body length (at the side of pins), default: 6.0
+        'body_height',			    # Body height without button, default 3.5
+        'cover_thickness',          # Thickness of cover, default 0.3
+        'has_pegs',                 # Must be True if switch has reference pegs at the bottom, default: False
+        'pegs_radius',              # Radius of the pegs, default: 1.0
+        'pegs_pitch',               # Pitch of pegs if more than one, default: 9.0
+        'pegs_heigth',              # Height of pegs, default: 1.5
+        'pin_pitch',                # pin pitch, default 2.54
+        'pin_thickness',            # thickness of pins, default 0.2
+        'distance_pinTip_rows',     # distance from tip of pin from row one to row two, default 10.0
+        'pin_width',                # pin width, default 0.6
+        'pin_length_below_body',    # length of THT pins below body, only necessary for THT pins, dafault 3.5
+        'terminal_shape',           # shape of terminal from class ShapeOfTerminal, default ShapeOfTerminal.GW
+        'button_dia',               # diameter button, default 3.5
+        'body_height_with_button',  # overall height of body incl. button, default 5.0
+        'button_type',              # Type of button from class ButtonType, default ButtonType.FLAT
+        'button_ring',              # Type of guide ring arround button, NONE if not present; default: ButtonRing.NONE
+        'button_ring_radius',       # radius of round button ring, default 2.35
+        'button_ring_heigth',       # height of button ring, default 1.6 
+        'button_ring_width',        # width of octacon button ring, default 3.7
+        'button_ring_length',       # length of octagon button ring, default 3.7 
+        'with_gnd_pin',             # boolean: True if Ground Terminal is present, default False 
+        'gnd_pin_tip_to_center',    # outer Pin tip (pin center for THT) of GND pin to center of body, default 4.0 
+        'no_gnd_pins',              # number of groung pins (1 or 2); default: 1
+        'offset_gnd_pin',           # offset of ground pin to middle of housing; default: 0.0
+        'gnd_pin_width',            # width of ground pin; default: pin_width
+        'serie',			        # The component serie, must be defined, no default value 
+        'cover_color_key',	        # Cover color, default 'metal grey pins'
+        'body_color_key',	        # Body colour, default 'black body'
+        'button_color_key',         # botton color, default 'black body'
+        'pin_color_key',	        # Pin color, default 'metal grey pins'
+        'destination_dir',	        # Destination directory, default 'Button_Switch_SMD.3dshapes'
+
+        # Python 2.x does not support extension of named tuple using _fields+(). 
+        # We must define all field names of derived classe here in this base class. The default valued will be set in the derived classes.
+
+        # fields for cq_cuk_kmr2x and cq_cuk_pts810x:
+        'button_oval_width',        # width of side actuated button, default: 2.11
+        'button_oval_length',       # length of side actuated button, default: 1.61
+
+        # fields for cq_ultra_small_tact_switch:
+        'button_side_width',        # width of side actuated button, default: 2.6
+        'button_side_height',       # hight of side actuated button, default: 1.4
+        'body_length_with_button',  # length of body incl. side actuated button, default: 4.5
+    ])
+
+
+    all_params = {
+
+        'SW_SPST_B3S-1000': Params(
+            modelName = 'SW_SPST_B3S-1000',   
+            body_width = 6.0,		    
+            body_length = 6.6,	       
+            body_height = 3.4,			
+            pin_pitch = 4.5,
+            distance_pinTip_rows = 9.0,
+            pin_width = 0.7,
+            pin_thickness = 0.1,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 3.3,
+            body_height_with_button = 4.3,
+            button_type = ButtonType.FLAT,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'orange body',        
+            pin_color_key = 'gold pins',  
+            serie = TactSwitchSeries.B3S,
+            destination_dir  = 'Button_Switch_SMD.3dshapes',      
+            ),
+
+        'SW_SPST_B3S-1100': Params(
+            modelName = 'SW_SPST_B3S-1100',   
+            body_width = 6.0,		    
+            body_length = 6.6,	       
+            body_height = 3.4,			
+            pin_pitch = 4.5,
+            distance_pinTip_rows = 9.0,
+            pin_width = 0.7,
+            pin_thickness = 0.1,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 3.3,
+            body_height_with_button = 4.3,
+            button_type = ButtonType.FLAT,
+            with_gnd_pin = True,
+            gnd_pin_tip_to_center = 4.2,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'gold pins',  
+            serie = TactSwitchSeries.B3S,
+            destination_dir = 'Button_Switch_SMD.3dshapes',     
+            ),
+
+        'SW_SPST_B3SL-1002P': Params(
+            modelName = 'SW_SPST_B3SL-1002P',   
+            body_width = 6.2,		    
+            body_length = 6.5,	       
+            body_height = 2.5,			
+            pin_pitch = 4.0,
+            distance_pinTip_rows = 7.0,
+            pin_width = 0.7,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.JH,
+            button_dia = 2.5,
+            body_height_with_button = 3.4,
+            button_type = ButtonType.FLAT,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'green body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3SL,
+            destination_dir  = 'Button_Switch_SMD.3dshapes',      
+            ),
+
+        'SW_SPST_B3SL-1022P': Params(
+            modelName = 'SW_SPST_B3SL-1022P',   
+            body_width = 6.2,		    
+            body_length = 6.5,	       
+            body_height = 2.5,			
+            pin_pitch = 4.0,
+            distance_pinTip_rows = 7.0,
+            pin_width = 0.7,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.JH,
+            button_dia = 2.5,
+            body_height_with_button = 5.1,
+            button_type = ButtonType.FLAT,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'grey body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3SL,
+            destination_dir  = 'Button_Switch_SMD.3dshapes',      
+            ),
+
+        'SW_SPST_B3U-1100P-B': Params(
+            modelName = 'SW_SPST_B3U-1100P-B',   
+            body_width = 3.0,		    
+            body_length = 2.5,	       
+            body_height = 1.2,
+            pin_pitch = 0.0,
+            distance_pinTip_rows = 4.0,
+            pin_width = 1.4,
+            pin_thickness = 0.2,
+            has_pegs = True,
+            pegs_radius = 0.65/2.0,
+            pegs_pitch = 0.0,
+            pegs_heigth = 0.5,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 1.5,
+            body_height_with_button = 1.6,
+            button_type = ButtonType.FLAT,
+            with_gnd_pin = True,
+            gnd_pin_tip_to_center = 1.9,
+            gnd_pin_width = 0.5,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3U1,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+        'SW_SPST_B3U-1100P': Params(
+            modelName = 'SW_SPST_B3U-1100P',   
+            body_width = 3.0,		    
+            body_length = 2.5,	       
+            body_height = 1.2,
+            pin_pitch = 0.0,
+            distance_pinTip_rows = 4.0,
+            pin_width = 1.4,
+            pin_thickness = 0.2,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 1.5,
+            body_height_with_button = 1.6,
+            button_type = ButtonType.FLAT,
+            with_gnd_pin = True,
+            gnd_pin_tip_to_center = 1.9,
+            gnd_pin_width = 0.5,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3U1,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+
+        'SW_SPST_Omron_B3FS-100xP': Params(
+            modelName = 'SW_SPST_Omron_B3FS-100xP',   
+            body_width = 6.0,		    
+            body_length = 6.3,	       
+            body_height = 2.6,			
+            pin_pitch = 4.5,
+            distance_pinTip_rows = 8.0,
+            pin_width = 0.7,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 3.0,
+            body_height_with_button = 3.1,
+            button_type = ButtonType.FLAT,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'blue body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3FS,
+            destination_dir  = 'Button_Switch_SMD.3dshapes',      
+            ),
+
+        'SW_SPST_Omron_B3FS-101xP': Params(
+            modelName = 'SW_SPST_Omron_B3FS-101xP',   
+            body_width = 6.0,		    
+            body_length = 6.3,	       
+            body_height = 2.6,			
+            pin_pitch = 4.5,
+            distance_pinTip_rows = 8.0,
+            pin_width = 0.7,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 3.0,
+            body_height_with_button = 4.3,
+            button_type = ButtonType.FLAT,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'blue body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3FS,
+            destination_dir  = 'Button_Switch_SMD.3dshapes',      
+            ),
+
+        'SW_SPST_Omron_B3FS-105xP': Params(
+            modelName = 'SW_SPST_Omron_B3FS-105xP',   
+            body_width = 6.0,		    
+            body_length = 6.3,	       
+            body_height = 2.6,			
+            pin_pitch = 4.5,
+            distance_pinTip_rows = 8.0,
+            pin_width = 0.7,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 3.0,
+            body_height_with_button = 7.3,
+            button_type = ButtonType.PROJ,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'yellow body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3FS,
+            destination_dir  = 'Button_Switch_SMD.3dshapes',      
+            ),
+
+        'SW_TH_Tactile_Omron_B3F-10xx': Params(
+            modelName = 'SW_TH_Tactile_Omron_B3F-10xx',   
+            body_width = 6.0,		    
+            body_length = 6.0,	       
+            body_height = 3.4,			
+            pin_pitch = 4.5,
+            distance_pinTip_rows = 6.5,
+            pin_width = 0.7,
+            pin_thickness = 0.3,
+            pin_length_below_body = 3.5,
+            terminal_shape = ShapeOfTerminal.THC,
+            button_dia = 3.5,
+            body_height_with_button = 4.3,
+            button_type = ButtonType.FLAT,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'yellow body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3F,
+            destination_dir = 'Button_Switch_THT.3dshapes',      
+            ),
+
+        'SW_TH_Tactile_Omron_B3F-11xx': Params(
+            modelName = 'SW_TH_Tactile_Omron_B3F-11xx',   
+            body_width = 6.0,		    
+            body_length = 6.0,	       
+            body_height = 3.4,			
+            pin_pitch = 4.5,
+            distance_pinTip_rows = 6.5,
+            pin_width = 0.7,
+            pin_thickness = 0.3,
+            pin_length_below_body = 3.5,
+            terminal_shape = ShapeOfTerminal.THC,
+            button_dia = 3.5,
+            body_height_with_button = 4.3,
+            button_type = ButtonType.FLAT,
+            with_gnd_pin = True,
+            gnd_pin_tip_to_center = 4.1,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'yellow body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3F,
+            destination_dir = 'Button_Switch_THT.3dshapes',      
+            ),
+
+        'SW_push_1P1T_NO_CK_KSC6xxJxxx': Params(
+            modelName = 'SW_push_1P1T_NO_CK_KSC6xxJxxx',   
+            body_width = 6.2,		    
+            body_length = 6.2,	       
+            body_height = 2.8,			
+            pin_pitch = 4.0,
+            distance_pinTip_rows = 6.8,
+            pin_width = 0.7,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.JH,
+            button_dia = 2.9,
+            body_height_with_button = 7.6,
+            button_type = ButtonType.FLAT,
+            button_ring = ButtonRing.ROUND,
+            button_ring_radius = 2.35,
+            button_ring_heigth = 1.6,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.KSC,
+            destination_dir = 'Button_Switch_SMD.3dshapes',      
+            ),
+
+        'SW_push_1P1T_NO_CK_KSC7xxJxxx': Params(
+            modelName = 'SW_push_1P1T_NO_CK_KSC7xxJxxx',   
+            body_width = 6.2,		    
+            body_length = 6.2,	       
+            body_height = 2.8,			
+            pin_pitch = 4.0,
+            distance_pinTip_rows = 6.8,
+            pin_width = 0.7,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.JH,
+            button_dia = 3.0,
+            body_height_with_button = 4.2,
+            button_type = ButtonType.FLAT,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'blue body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.KSC,
+            destination_dir = 'Button_Switch_SMD.3dshapes',      
+            ),
+
+        'SW_SPST_EVPBF': Params(
+           modelName = 'SW_SPST_EVPBF',  
+           body_width = 6.0,		    
+           body_length = 6.0,	       
+           body_height = 2.5,
+           cover_thickness = 0.15,
+           pin_pitch = 4.0,
+           distance_pinTip_rows = 6.6,
+           pin_width = 0.8,
+           pin_thickness = 0.2,
+           terminal_shape = ShapeOfTerminal.JH,
+           button_dia = 3.4,
+           body_height_with_button = 3.5,
+           button_type = ButtonType.FLAT,
+           cover_color_key = 'metal grey pins',        
+           body_color_key = 'black body',        
+           button_color_key = 'white body',        
+           pin_color_key = 'metal silver',  
+           serie = TactSwitchSeries.EVPBF,
+           destination_dir = 'Button_Switch_SMD.3dshapes',    
+           ),
+
+        'SW_SPST_EVQP0': Params(
+           modelName = 'SW_SPST_EVQP0',  
+           body_width = 6.2,		    
+           body_length = 6.0,	       
+           body_height = 1.8,
+           cover_thickness = 0.15,
+           pin_pitch = 4.0,
+           distance_pinTip_rows = 6.6,
+           pin_width = 0.8,
+           pin_thickness = 0.2,
+           terminal_shape = ShapeOfTerminal.JH,
+           button_dia = 2.0,
+           body_height_with_button = 2.5,
+           button_type = ButtonType.FLAT,
+           cover_color_key = 'metal grey pins',        
+           body_color_key = 'black body',        
+           button_color_key = 'blue body',        
+           pin_color_key = 'metal silver',  
+           serie = TactSwitchSeries.EVQP0,
+           destination_dir = 'Button_Switch_SMD.3dshapes',    
+           ),
+
+        'SW_SPST_EVQP2': Params(
+           modelName = 'SW_SPST_EVQP2',  
+           body_width = 4.7,		    
+           body_length = 3.5,	       
+           body_height = 1.65,
+           cover_thickness = 0.15,
+           pin_pitch = 1.7,
+           distance_pinTip_rows = 5.5,
+           pin_width = 0.6,
+           pin_thickness = 0.2,
+           terminal_shape = ShapeOfTerminal.JH,
+           button_dia = 1.8,
+           body_height_with_button = 2.5,
+           button_type = ButtonType.FLAT,
+           cover_color_key = 'metal grey pins',        
+           body_color_key = 'black body',        
+           button_color_key = 'grey body',        
+           pin_color_key = 'metal silver',  
+           serie = TactSwitchSeries.EVQP2,
+           destination_dir = 'Button_Switch_SMD.3dshapes',    
+           ),
+
+        'SW_SPST_Panasonic_EVQPL_3PL_5PL_PT_A08': Params(
+           modelName = 'SW_SPST_Panasonic_EVQPL_3PL_5PL_PT_A08',  
+           body_width = 4.9,		    
+           body_length = 4.9,	       
+           body_height = 0.8,
+           cover_thickness = 0.15,
+           pin_pitch = 3.7,
+           distance_pinTip_rows = 5.2,
+           pin_width = 0.5,
+           pin_thickness = 0.2,
+           terminal_shape = ShapeOfTerminal.JH,
+           button_dia = 3.2,
+           body_height_with_button = 0.8,
+           button_type = ButtonType.FLAT,
+           with_gnd_pin = True,
+           gnd_pin_tip_to_center = 4.9/2.0,
+           no_gnd_pins = 2,
+           offset_gnd_pin = 0.35, 
+           gnd_pin_width = 0.3,
+           cover_color_key = 'metal grey pins',        
+           body_color_key = 'black body',        
+           button_color_key = 'white body',        
+           pin_color_key = 'metal silver',  
+           serie = TactSwitchSeries.EVQPL,
+           destination_dir = 'Button_Switch_SMD.3dshapes',    
+           ),
+
+
+        'SW_SPST_Panasonic_EVQPL_3PL_5PL_PT_A15': Params(
+           modelName = 'SW_SPST_Panasonic_EVQPL_3PL_5PL_PT_A15',  
+           body_width = 4.9,		    
+           body_length = 4.9,	       
+           body_height = 0.8,
+           cover_thickness = 0.15,
+           pin_pitch = 3.7,
+           distance_pinTip_rows = 5.2,
+           pin_width = 0.5,
+           pin_thickness = 0.2,
+           terminal_shape = ShapeOfTerminal.JH,
+           button_dia = 3.2,
+           body_height_with_button = 1.5,
+           button_type = ButtonType.FLAT,
+           button_ring = ButtonRing.OCTA,
+           button_ring_width = 3.7,
+           button_ring_length = 3.7,
+           button_ring_heigth = 0.4,
+           with_gnd_pin = True,
+           gnd_pin_tip_to_center = 4.9/2.0,
+           no_gnd_pins = 2,
+           offset_gnd_pin = 0.35, 
+           gnd_pin_width = 0.3,
+           cover_color_key = 'metal grey pins',        
+           body_color_key = 'black body',        
+           button_color_key = 'white body',        
+           pin_color_key = 'metal silver',  
+           serie = TactSwitchSeries.EVQPL,
+           destination_dir = 'Button_Switch_SMD.3dshapes',    
+           ),
+
+
+        'SW_Tactile_Straight_KSA0Axx1LFTR': Params(
+           modelName = 'SW_Tactile_Straight_KSA0Axx1LFTR',  
+           body_width = 7.4,		    
+           body_length = 7.3,	       
+           body_height = 2.6,
+           cover_thickness = 0.3,
+           pin_pitch = 5.08,
+           distance_pinTip_rows = 7.65,
+           pin_width = 0.53,
+           pin_thickness = 0.3,
+           pin_length_below_body = 4.2,
+           terminal_shape = ShapeOfTerminal.THC,
+           button_dia = 3.0,
+           body_height_with_button = 4.7,
+           button_type = ButtonType.FLAT,
+           button_ring = ButtonRing.ROUND,
+           button_ring_radius = 2.4,
+           button_ring_heigth = 1.1,
+           cover_color_key = 'metal grey pins',        
+           body_color_key = 'black body',        
+           button_color_key = 'blue body',        
+           pin_color_key = 'metal silver',  
+           serie = TactSwitchSeries.KSx0A,
+           destination_dir = 'Button_Switch_THT.3dshapes',    
+           ),
+
+
+        'SW_Tactile_Straight_KSL0Axx1LFTR': Params(
+           modelName = 'SW_Tactile_Straight_KSL0Axx1LFTR',  
+           body_width = 7.4,		    
+           body_length = 7.3,	       
+           body_height = 2.6,
+           cover_thickness = 0.3,
+           pin_pitch = 5.08,
+           distance_pinTip_rows = 7.65,
+           pin_width = 0.53,
+           pin_thickness = 0.3,
+           pin_length_below_body = 4.2,
+           terminal_shape = ShapeOfTerminal.THC,
+           button_dia = 3.0,
+           body_height_with_button = 9.9,
+           button_type = ButtonType.FLAT,
+           button_ring = ButtonRing.ROUND,
+           button_ring_radius = 2.4,
+           button_ring_heigth = 1.1,
+           cover_color_key = 'metal grey pins',        
+           body_color_key = 'black body',        
+           button_color_key = 'red body',        
+           pin_color_key = 'metal silver',  
+           serie = TactSwitchSeries.KSx0A,
+           destination_dir = 'Button_Switch_THT.3dshapes',    
+           ),
+
+        'SW_PUSH_6mm_H8.5mm': Params(
+            modelName = 'SW_PUSH_6mm_H8.5mm',   
+            body_width = 6.0,		    
+            body_length = 6.0,	       
+            body_height = 3.6,			
+            pin_pitch = 4.5,
+            distance_pinTip_rows = 6.5,
+            pin_width = 0.7,
+            pin_thickness = 0.3,
+            pin_length_below_body = 3.5,
+            terminal_shape = ShapeOfTerminal.THL,
+            button_dia = 3.5,
+            body_height_with_button = 8.5,
+            button_type = ButtonType.FLAT,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3F,
+            destination_dir = 'Button_Switch_THT.3dshapes',      
+            ),
+
+
+        'SW_PUSH_6mm_H9.5mm': Params(
+            modelName = 'SW_PUSH_6mm_H9.5mm',   
+            body_width = 6.0,		    
+            body_length = 6.0,	       
+            body_height = 3.45,			
+            pin_pitch = 4.5,
+            distance_pinTip_rows = 9.0,
+            pin_width = 0.7,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 3.5,
+            body_height_with_button = 9.5,
+            button_type = ButtonType.FLAT,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3F,
+            destination_dir = 'Button_Switch_SMD.3dshapes',      
+            ),
+
+        'SW_SPST_SKQG_WithStem': Params(
+           modelName = 'SW_SPST_SKQG_WithStem',  
+           body_width = 5.2,		    
+           body_length = 5.2,	       
+           body_height = 0.8,
+           cover_thickness = 0.15,
+           pin_pitch = 3.7,
+           distance_pinTip_rows = 6.4,
+           pin_width = 0.5,
+           pin_thickness = 0.15,
+           terminal_shape = ShapeOfTerminal.GW,
+           button_dia = 2.0,
+           body_height_with_button = 1.5,
+           button_type = ButtonType.FLAT,
+           button_ring = ButtonRing.OCTA,
+           button_ring_width = 3.7,
+           button_ring_length = 3.7,
+           button_ring_heigth = 0.4,
+           cover_color_key = 'metal grey pins',        
+           body_color_key = 'black body',        
+           button_color_key = 'white body',        
+           pin_color_key = 'metal silver',  
+           serie = TactSwitchSeries.SKOG,
+           destination_dir = 'Button_Switch_SMD.3dshapes',    
+           ),
+
+
+        'SW_SPST_SKQG_WithoutStem': Params(
+           modelName = 'SW_SPST_SKQG_WithoutStem',  
+           body_width = 5.2,		    
+           body_length = 5.2,	       
+           body_height = 0.8,
+           cover_thickness = 0.15,
+           pin_pitch = 3.7,
+           distance_pinTip_rows = 6.4,
+           pin_width = 0.5,
+           pin_thickness = 0.15,
+           terminal_shape = ShapeOfTerminal.GW,
+           button_dia = 2.0,
+           body_height_with_button = 0.7,
+           button_type = ButtonType.FLAT,
+           cover_color_key = 'metal grey pins',        
+           body_color_key = 'black body',        
+           button_color_key = 'black body',        
+           pin_color_key = 'metal silver',  
+           serie = TactSwitchSeries.SKOG,
+           destination_dir = 'Button_Switch_SMD.3dshapes',    
+           ),
+
+
+        
+        'SW_SPST_TL3305A': Params(
+            modelName = 'SW_SPST_TL3305A',   
+            body_width = 4.5,		    
+            body_length = 4.5,	       
+            body_height = 3.0,			
+            pin_pitch = 3.0,
+            distance_pinTip_rows = 7.5,
+            pin_width = 0.7,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 2.5,
+            body_height_with_button = 3.8,
+            button_type = ButtonType.FLAT,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3F,   # Tact switch bodys from E-Switch serie TL3305 are similar to Omron B3F, but TL3305 are SMD type
+            destination_dir = 'Button_Switch_SMD.3dshapes',      
+            ),
+        
+
+        'SW_SPST_TL3305B': Params(
+            modelName = 'SW_SPST_TL3305B',   
+            body_width = 4.5,		    
+            body_length = 4.5,	       
+            body_height = 3.0,			
+            pin_pitch = 3.0,
+            distance_pinTip_rows = 7.5,
+            pin_width = 0.7,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 2.5,
+            body_height_with_button = 5.0,
+            button_type = ButtonType.FLAT,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3F,      # Tact switch bodys from E-Switch serie TL3305 are similar to Omron B3F, but TL3305 are SMD type
+            destination_dir = 'Button_Switch_SMD.3dshapes',      
+            ),
+
+
+        'SW_SPST_TL3305C': Params(
+            modelName = 'SW_SPST_TL3305C',   
+            body_width = 4.5,		    
+            body_length = 4.5,	       
+            body_height = 3.0,			
+            pin_pitch = 3.0,
+            distance_pinTip_rows = 7.5,
+            pin_width = 0.7,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 2.5,
+            body_height_with_button = 7.0,
+            button_type = ButtonType.FLAT,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3F,      # Tact switch bodys from E-Switch serie TL3305 are similar to Omron B3F, but TL3305 are SMD type
+            destination_dir = 'Button_Switch_SMD.3dshapes',      
+            ),
+
+
+        'SW_Push_SPST_NO_Alps_SKRK': Params(
+            modelName = 'SW_Push_SPST_NO_Alps_SKRK',   
+            body_width = 3.9,		    
+            body_length = 2.9,	       
+            body_height = 1.5,
+            pin_pitch = 0.0,
+            distance_pinTip_rows = 4.8,
+            pin_width = 1.4,
+            pin_thickness = 0.2,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 1.8,
+            body_height_with_button = 2.0,
+            button_type = ButtonType.FLAT,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'white body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.SKRK,          
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+
+    }
+
+
+                

--- a/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_cuk_kmr2x.py
+++ b/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_cuk_kmr2x.py
@@ -1,0 +1,379 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# This script is derived from a script for generating  DIP_parts and Buzzer_Beeper scripts
+#
+# Dimensions are from data sheets given in the settings of the corresponding KiCad footprint:
+
+## requirements
+## cadquery FreeCAD plugin
+##   https://github.com/jmwright/cadquery-freecad-module
+
+## to run the script just do: freecad main_generator.py modelName
+## e.g. c:\freecad\bin\freecad main_generator.py *b3fs*
+
+## to run the script just do: freecad main_generator.py modelName
+## e.g. c:\freecad\bin\freecad main_generator.py *b3fs*
+
+## the script will generate STEP and VRML parametric models
+## to be used with kicad StepUp script
+
+#* These are a FreeCAD & cadquery tools                                     *
+#* to export generated models in STEP & VRML format.                        *
+#*                                                                          *
+#* cadquery script for generating QFP/SOIC/SSOP/TSSOP models in STEP AP214  *
+#*   Copyright (c) 2015                                                     *
+#* Maurice https://launchpad.net/~easyw                                     *
+#*                                                                          *
+#*   Copyright (c) 2020                                                     *
+#* Mountyrox   https://github.com/mountyrox                                 *
+#*                                                                          *
+#* All trademarks within this guide belong to their legitimate owners.      *
+#*                                                                          *
+#*   This program is free software; you can redistribute it and/or modify   *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)     *
+#*   as published by the Free Software Foundation; either version 2 of      *
+#*   the License, or (at your option) any later version.                    *
+#*   for detail see the LICENCE text file.                                  *
+#*                                                                          *
+#*   This program is distributed in the hope that it will be useful,        *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+#*   GNU Library General Public License for more details.                   *
+#*                                                                          *
+#*   You should have received a copy of the GNU Library General Public      *
+#*   License along with this program; if not, write to the Free Software    *
+#*   Foundation, Inc.,                                                      *
+#*   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA           *
+#*                                                                          *
+#****************************************************************************
+import operator
+
+import cadquery as cq
+from Helpers import show
+
+import FreeCAD, Draft, FreeCADGui
+import ImportGui
+import FreeCADGui as Gui
+
+import shaderColors
+import exportPartToVRML as expVRML
+
+# Import cad_tools
+import cq_cad_tools
+# Reload tools
+from cq_cad_tools import reload_lib
+reload_lib(cq_cad_tools)
+# Explicitly load all needed functions
+from cq_cad_tools import FuseObjs_wColors, GetListOfObjects, z_RotateObject, Color_Objects, restore_Main_Tools, exportSTEP, saveFCdoc
+
+import cq_parameters  # modules parameters
+from cq_parameters import ShapeOfTerminal, ButtonType, partParamsTactSwitches
+
+import collections
+from collections import namedtuple
+
+
+from  cq_base_model import PartBase, Polyline  # modules parameters
+
+from cq_base_tact_switches import cqMakerTactSwitch, TactSwitchSeries, partsTactSwitches
+
+
+
+
+class TactSwitchSeries (TactSwitchSeries):
+    r"""A class for holding C&K tactile switch series KMR2x
+
+    .. note:: will be changed to enum when Python version allows it
+    """
+    KMR2 = 'KMR2'
+    r"""KMR2: 12 mm Tact Switch for SMT and THT. 
+    """
+    
+
+
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*      class cqMakerCuK_Kmr2xTactSwitch (cqMakerTactSwitch)                *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+
+class cqMakerCuK_Kmr2xTactSwitch (cqMakerTactSwitch):
+    r"""A class for creating a 3D models from C&K type KMR2. The parameter are defined in the class ``parts_cuk_kmr2``
+    :param parameter: namedtuple containing the variable parameter for building the different 3D models.
+    :type  parameter: ``partsTactSwitches.Params``
+
+    """
+    def __init__(self, parameter):
+        cqMakerTactSwitch.__init__(self, parameter)
+        
+        self.button_oval_width = parameter.button_oval_width if parameter.button_oval_width != None else 2.11                            
+        self.button_oval_length = parameter.button_oval_length if parameter.button_oval_length != None else 1.61                             
+        #self. = parameter. if parameter. != None else                              
+
+    def _paramsForKMR2 (self):
+        r"""set the reqired dimensions for tactile switch serie C&K PTS125S
+
+        """
+        self.cover_thickness = 0.1
+        self.body_board_distance = 0.0
+
+        self.pad_side_height = 0.6
+        self.pad_side_width  = 2.0 * self.cover_thickness
+        self.pad_side_length = 0.7
+
+        self.pin_bottom_length = 0.6
+
+        # Dimension of metallic cover plate
+        self.cover_side_height =  1.0
+        self.offsets = (0.0, 0.0, 0.0)
+
+
+    # Append the series switcher
+    cqMakerTactSwitch._serieSwitcher[TactSwitchSeries.KMR2] = _paramsForKMR2  
+
+    def _padsSideCenter (self):
+        r"""generates a body to be placed (central) at the top side of the parts body. These side pads are the fixing elements for the cover clips.
+
+        :rtype: ``solid``
+        """
+        pad = cq.Workplane("XY", origin=(0.0, self.body_width / 2.0 - self.cover_thickness, self.body_height - self.cover_thickness - self.pad_side_height))\
+                    .rect(self.pad_side_length, self.pad_side_width).extrude(self.pad_side_height)\
+                    .edges(">Z").edges(">Y").fillet(self.pad_side_width * 0.99)
+
+        return pad.union(pad.mirror("XZ"))
+
+    
+    def makePlasticCase (self):
+        """ create the plastic body of the tactile switch
+        :rtype: ``solid``
+        """
+
+        body = cq.Workplane("XY")\
+                 .rect(self.body_length, self.body_width - 2.0 * self.pad_side_width).extrude(self.body_height - self.cover_thickness)
+
+        body = body.edges("|Z").fillet(0.2).union(self._padsSideCenter())
+
+        if self.with_gnd_pin:
+            pocket = cq.Workplane("YZ")\
+                .rect(self.gnd_pin_width * 1.1, 2.0*self.body_height).extrude(self.cover_thickness*2.0)\
+                .translate((self.body_length / 2.0 - self.cover_thickness, 0.0, 0.0))
+            body = body.cut(pocket)
+
+        return body
+
+
+    def _coverSideSheetsClosed (self):
+        r"""generates a body used as a side clip of the top cover sheet. The shape of the side clip is a closed frame.
+        The side clips will be placed at the sides where are no pins.
+
+        :rtype: ``solid``
+        """
+        ul = self.pad_side_length + 1.4   # upper length of side sheet
+        ll = self.pad_side_length + 0.8   # lower length of side sheet
+        body = Polyline(cq.Workplane("XZ").workplane(offset=self.body_width / 2.0 - self.pad_side_width - self.cover_thickness))\
+            .addMoveTo(-self.pad_side_length / 2.0, self.body_height)\
+            .addPoint(-(ul - self.pad_side_length) / 2.0, 0.0)\
+            .addPoint((ul-ll) / 2.0, -self.cover_side_height)\
+            .addPoint(ll, 0.0)\
+            .addPoint((ul-ll) / 2.0, self.cover_side_height)\
+            .addPoint(-(ul - self.pad_side_length) / 2.0, 0.0)\
+            .addPoint(0.0, -(self.pad_side_height + self.cover_thickness))\
+            .addPoint(-self.pad_side_length, 0.0)\
+            .make().extrude(2.0*self.cover_thickness).edges(">Z").edges("<Y").fillet(2.0*self.cover_thickness*0.8)
+
+        #body = body.edges("|Z").fillet(0.05)
+        body = body.edges("<Z").edges("|Y").fillet(0.2)
+
+        body = body.union(body.mirror("XZ"))
+
+        return body
+
+    def _makeGndPin (self, pin_width = None, pin_thickness = None):
+        r"""generates a pin connected to the top metallic cover sheet used as a ground pin.
+
+        :rtype: ``solid``
+        """
+
+        if pin_width is None:
+            pin_width = self.gnd_pin_width
+
+        if pin_thickness is None:
+             pin_thickness = self.cover_thickness
+
+        gndPin = cq.Workplane("YZ")\
+            .rect(self.gnd_pin_width, self.body_height).extrude(self.cover_thickness)\
+            .translate((self.body_length / 2.0 - self.cover_thickness, 0.0, self.body_height/2.0))\
+            .edges(">Z").edges(">X").fillet(self.cover_thickness*0.99)\
+            .edges("<Z").edges("|X").fillet(0.2)\
+
+
+        return gndPin
+
+
+    def makeCoverPlate (self):
+        """ create the outer metal frame of switch
+        :rtype: ``solid``
+        """
+        # body of cover with button hole completely filled
+        body = cq.Workplane("XY")\
+                    .rect(self.body_length, self.body_width - 6.0 * self.cover_thickness)\
+                    .extrude(self.cover_thickness)
+
+        s = cq.StringSyntaxSelector
+        #body = body.edges(s(">Z")-s(">Y")-s("<Y")-s("<X")-s(">X")).fillet(self.cover_thickness*0.25)
+
+        body = body.edges("|Z").fillet(0.2)#.cut(self.makeButton(self.button_oval_length + 0.1, self.button_oval_width + 0.1))\
+       
+        body = body.translate((0.0, 0.0, self.body_height - self.cover_thickness)).union(self._coverSideSheetsClosed())\
+            .cut(self.makeButton(self.button_oval_length + 0.1, self.button_oval_width + 0.1))
+
+        if self.with_gnd_pin:
+            pocket = cq.Workplane("YZ")\
+                .rect(self.gnd_pin_width * 1.6, self.body_height).extrude(self.cover_thickness*2.0)\
+                .translate((self.body_length / 2.0 - self.cover_thickness, 0.0, self.body_height))\
+                .edges("|Z").fillet(self.cover_thickness*0.99)
+
+            body = body.cut(pocket).union(self._makeGndPin())
+
+        #body = body.edges(">Z").fillet(0.015)
+
+        return body
+
+    def makeButton (self, button_length = None, button_width = None):
+        """ create the button of switch, depending on button type 
+        :param button_length: length of oval botton (default: button_oval_length as defined in all_parameter)
+        :type button_length: ``float``
+        :param button_width: width of oval botton (default: button_oval_width as defined in all_parameter)
+        :type button_width: ``float``
+        :rtype: ``solid``
+        """
+        if button_length is None:
+            button_length = self.button_oval_length
+
+        if button_width is None:
+            button_width  = self.button_oval_width
+
+        button_height = self.body_height_with_button - self.body_height + self.cover_thickness
+        fw = 0.15
+
+        s = cq.StringSyntaxSelector
+        body = Polyline(cq.Workplane("XY"))\
+            .addMoveTo(button_length / 2.0, 0.0)\
+            .addPoint(-button_length * fw, -button_width / 2.0)\
+            .addPoint(-button_length * (1.0 - 2.0 * fw), 0.0)\
+            .addPoint(-button_length * fw, button_width / 2.0)\
+            .addPoint(+button_length * fw, button_width / 2.0)\
+            .addPoint(+button_length * (1.0 - 2.0 * fw), 0.0)\
+            .addPoint(+button_length * fw, -button_width / 2.0)\
+            .make().extrude(button_height)\
+            .edges(s(">X") + s("<X")).fillet(0.4)\
+            .edges("|Z").edges("<Y").fillet(0.4)\
+            .edges("|Z").edges(">Y").fillet(0.4)\
+            .edges(">Z").fillet(0.05)
+
+
+        #body = body.edges("|Z").fillet(0.2)
+       
+        body = body.translate((0.0, 0.0, self.body_height - self.cover_thickness))
+        return body
+
+
+
+
+        
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+
+class parts_cuk_kmr2 (partsTactSwitches):
+    r"""A class for defining parameter of C6K tactile switches type KMR2. 
+
+    """
+
+        
+    def getModelVariant (self, modelName):
+        r"""returns the parameter namedtuple from ``all_params`` for the given model name
+        
+        :param modelName: name of the model as defined in ``all_params``
+        :type modelName: ``string``
+        :rtype: ``namedtuple``
+        """
+        return cqMakerCuK_Kmr2xTactSwitch (self.all_params[modelName])
+
+    # will be used if Python version allows it
+    #try:
+    #    # extend the ParamsWithDefault named tuple by 'point'
+    #    partsTactSwitches.Params = partsTactSwitches.namedtuple_with_defaults('Params',partsTactSwitches.Params.\
+    #        _fields+('button_oval_width', 'button_oval_length'))
+    #except:
+    #    FreeCAD.Console.PrintMessage('invalid or duplicate field names.\r\n')
+
+
+    all_params = {
+
+        'SW_Push_1P1T-SH_NO_CK_KMR2xxG': partsTactSwitches.Params(
+            modelName = 'SW_Push_1P1T-SH_NO_CK_KMR2xxG',  
+            body_width = 4.2,		    
+            body_length = 2.8,	       
+            body_height = 1.4,
+            pin_pitch = 1.6,
+            distance_pinTip_rows = 4.6,
+            pin_width = 0.6,
+            pin_thickness = 0.15,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_oval_width = 2.11,
+            button_oval_length = 1.61,
+            body_height_with_button = 1.9,
+            button_type = ButtonType.FLAT,
+            with_gnd_pin = True,
+            gnd_pin_width = 1.2,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.KMR2,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+        'SW_Push_1P1T_NO_CK_KMR2': partsTactSwitches.Params(
+            modelName = 'SW_Push_1P1T_NO_CK_KMR2',  
+            body_width = 4.2,		    
+            body_length = 2.8,	       
+            body_height = 1.4,
+            pin_pitch = 1.6,
+            distance_pinTip_rows = 4.6,
+            pin_width = 0.6,
+            pin_thickness = 0.15,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_oval_width = 2.11,
+            button_oval_length = 1.61,
+            body_height_with_button = 1.9,
+            button_type = ButtonType.FLAT,
+            with_gnd_pin = False,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.KMR2,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+    }
+
+

--- a/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_cuk_pts125sx.py
+++ b/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_cuk_pts125sx.py
@@ -1,0 +1,545 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# This script is derived from a script for generating  DIP_parts and Buzzer_Beeper scripts
+#
+# Dimensions are from data sheets given in the settings of the corresponding KiCad footprint:
+
+## requirements
+## cadquery FreeCAD plugin
+##   https://github.com/jmwright/cadquery-freecad-module
+
+## to run the script just do: freecad main_generator.py modelName
+## e.g. c:\freecad\bin\freecad main_generator.py *b3fs*
+
+## to run the script just do: freecad main_generator.py modelName
+## e.g. c:\freecad\bin\freecad main_generator.py *b3fs*
+
+## the script will generate STEP and VRML parametric models
+## to be used with kicad StepUp script
+
+#* These are a FreeCAD & cadquery tools                                     *
+#* to export generated models in STEP & VRML format.                        *
+#*                                                                          *
+#* cadquery script for generating QFP/SOIC/SSOP/TSSOP models in STEP AP214  *
+#*   Copyright (c) 2015                                                     *
+#* Maurice https://launchpad.net/~easyw                                     *
+#* All trademarks within this guide belong to their legitimate owners.      *
+#*                                                                          *
+#*   Copyright (c) 2020                                                     *
+#* Mountyrox   https://github.com/mountyrox                                 *
+#*                                                                          *
+#*   This program is free software; you can redistribute it and/or modify   *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)     *
+#*   as published by the Free Software Foundation; either version 2 of      *
+#*   the License, or (at your option) any later version.                    *
+#*   for detail see the LICENCE text file.                                  *
+#*                                                                          *
+#*   This program is distributed in the hope that it will be useful,        *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+#*   GNU Library General Public License for more details.                   *
+#*                                                                          *
+#*   You should have received a copy of the GNU Library General Public      *
+#*   License along with this program; if not, write to the Free Software    *
+#*   Foundation, Inc.,                                                      *
+#*   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA           *
+#*                                                                          *
+#****************************************************************************
+import operator
+
+import cadquery as cq
+from Helpers import show
+
+import FreeCAD, Draft, FreeCADGui
+import ImportGui
+import FreeCADGui as Gui
+
+import shaderColors
+import exportPartToVRML as expVRML
+
+# Import cad_tools
+import cq_cad_tools
+# Reload tools
+from cq_cad_tools import reload_lib
+reload_lib(cq_cad_tools)
+# Explicitly load all needed functions
+from cq_cad_tools import FuseObjs_wColors, GetListOfObjects, z_RotateObject, Color_Objects, restore_Main_Tools, exportSTEP, saveFCdoc
+
+import cq_parameters  # modules parameters
+from cq_parameters import ShapeOfTerminal, ButtonType, partParamsTactSwitches
+
+import collections
+from collections import namedtuple
+
+
+from  cq_base_model import PartBase, Polyline  # modules parameters
+
+from cq_base_tact_switches import cqMakerTactSwitch, TactSwitchSeries, partsTactSwitches
+
+
+class ButtonType (ButtonType):
+    r"""A class for holding type of button of Omron tactile switch series
+
+    .. note:: will be changed to enum when Python version allows it
+    """
+    RIBS = 'RIBS'
+    r"""RIBS: Round actuator with ribs
+    """
+
+
+class TactSwitchSeries (TactSwitchSeries):
+    r"""A class for holding C&K tactile switch series PTS125Sx
+
+    .. note:: will be changed to enum when Python version allows it
+    """
+    PTS125S = 'PTS125S'
+    r"""PTS125S: 12 mm Tact Switch for SMT and THT. 
+    """
+    WS_TATV = 'WS_TATV'
+    r"""WS_TATV: 12 mm Tact Switch for THT from Wuerth Electronics. 
+    """
+    
+
+
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*   class cqMakerCuKPTS125SxTactSwitch (cqMakerTactSwitch)                 *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+
+class cqMakerCuKPTS125SxTactSwitch (cqMakerTactSwitch):
+    r"""A class for creating a 3D models from C&K type PTS125S and Wuerth TATV. The parameter are defined in the class ``parts_cuk_pts125s``
+    :param parameter: namedtuple containing the variable parameter for building the different 3D models.
+    :type  parameter: ``partsTactSwitches.Params``
+
+    """
+    
+    def __init__(self, parameter):
+        cqMakerTactSwitch.__init__(self, parameter)
+        
+        # get all entries of the params list as dictionary
+        args = parameter._asdict()
+        self.pad_bottom_height = 0.3
+
+        # for projected button type some more dimensions are needed
+        self.button_proj_length_top = self.button_dia - 3.2  
+        self.button_proj_length_mid = self.button_dia - 4.0 
+
+
+
+    def _paramsForPTS125S (self):
+        r"""set the reqired dimensions for tactile switch serie C&K PTS125S
+
+        """
+        self.cover_width = self.body_width - 2.2    
+        self.cover_length = self.body_length - 2.2 
+
+        self.body_board_distance = 0.0
+        self.machineEdges = self.__chamferEdges
+        self.cover_body_gap = 0.6
+
+        
+    def _paramsForWS_TATV (self):
+        r"""set the reqired dimensions for tactile switch serie Wuerth WS_TATV
+
+        """
+        self.cover_width = self.body_width - 1.0   
+        self.cover_length = self.body_length - 1.0
+        self.cover_body_gap = 0.01
+        
+        self.machineEdges = self.__filletEdges
+        
+
+
+    # Append the series switcher
+    cqMakerTactSwitch._serieSwitcher[TactSwitchSeries.PTS125S] = _paramsForPTS125S  
+    cqMakerTactSwitch._serieSwitcher[TactSwitchSeries.WS_TATV] = _paramsForWS_TATV  
+
+    def calcChamfer (self, width):
+        """ returns a value to be used to chamfer edges. The returned value will be calculated from the given width.
+       Normally the width is the x or y dimension of the body, if edges parallel to the Z axis will be chamfered.
+        
+        :param width: width of the body
+        :type width: ``float``
+
+        :rtype: ``solid``
+        """
+        return 0.3 * width - 2.1
+
+    def calcFillet (self, width):
+        """ returns a value to be used to fillet edges. The returned value will be calculated from the given width.
+       Normally the width is the x or y dimension of the body, if edges parallel to the Z axis will be filleted.
+        
+        :param width: width of the body
+        :type width: ``float``
+
+        :rtype: ``solid``
+        """
+        return 0.08 * width
+
+
+    def __padsBottom (self):
+        r"""generates a body to be placed as pads at the bottom of the parts body. Four pads will be generated.
+
+        :rtype: ``solid``
+        """
+        pad = Polyline(cq.Workplane("XY"), origin=(-self.pin_pitch/2.0 - 1.8, self.body_width/2.0 - 0.5))\
+                            .addPoint(1.8, 0.0)\
+                            .addPoint(0.0, -3.0)\
+                            .addPoint(-3.0, 0.0)\
+                            .addPoint(0.0, 1.8)\
+                            .make().extrude(self.pad_bottom_height)
+
+        pad = pad.union(pad.mirror("XZ"))
+        return pad.union(pad.mirror("YZ"))
+        
+    def __padsTop (self):
+        r"""generates a body to be placed as frame at the bottom of the parts body surrounding the metallic cover sheet.
+
+        :rtype: ``solid``
+        """
+        body = cq.Workplane("XY").workplane(offset=self.body_height_plastic)\
+                 .rect(self.body_length, self.body_width).extrude(self.cover_thickness)
+
+        body = self.machineEdges (body, self.body_width)
+                 #.edges("|Z").chamfer(self.calcChamfer(self.body_width))
+
+        pw = self.cover_width +  self.cover_body_gap
+        pl = self.cover_length +  self.cover_body_gap
+        pocket = cq.Workplane("XY").workplane(offset=self.body_height_plastic)\
+                 .rect(pl, pw).extrude(self.cover_thickness)
+
+        pocket = self.machineEdges (pocket, pw)
+                 #.edges("|Z").chamfer(self.calcChamfer(pw))
+
+        body = body.cut(pocket)
+
+        pocket = cq.Workplane("XY").workplane(offset=self.body_height_plastic)\
+                 .rect(1.5, self.body_width).extrude(self.cover_thickness)
+
+        body = body.cut(pocket)
+
+        return body
+    
+    def __chamferEdges (self, body, width):
+        """ chamfer edges |Z of the given body.
+        
+        :param body: body to be chamfered
+        :type body: ``solid``
+        :param width: width of the body
+        :type width: ``float``
+
+        :rtype: ``solid``
+        """
+        return body.edges("|Z").chamfer(self.calcChamfer(width))
+
+
+    def __filletEdges (self, body, width):
+        """ fillet edges |Z of the given body.
+        
+        :param body: body to be filleted
+        :type body: ``solid``
+        :param width: width of the body
+        :type width: ``float``
+
+        :rtype: ``solid``
+        """
+        return body.edges("|Z").fillet(self.calcFillet(width))
+
+    
+    def makePlasticCase (self):
+        """ create the plastic body of the tactile switch
+        :rtype: ``solid``
+        """
+        body = cq.Workplane("XY")\
+                 .rect(self.body_length, self.body_width).extrude(self.body_height_plastic-self.pad_bottom_height)\
+                 .translate((0.0, 0.0, self.pad_bottom_height))
+
+        body = self.machineEdges (body, self.body_width)
+                # .edges("|Z").chamfer(self.calcChamfer(self.body_width))
+        
+        body = body.union(self._mountingPads((self.cover_length / 2.0 * 0.8, self.cover_width / 2.0 * 0.8), 0.65))
+        body = body.union(self.__padsBottom())
+        body = body.union(self.__padsTop())
+        
+        if self.has_pegs:
+            body = body.union(self._pegs().translate((0.0, 0.0, self.pad_bottom_height)))
+
+        return body
+
+
+    def __pocketCoverSide (self):
+        l = 0.5  # length of pocket
+        w = 1.0  # width of pocket
+        pocket = cq.Workplane("XY").box(l, w, 2.0 * self.cover_thickness)\
+                   .translate (((self.cover_length - l)/2.0, 1.6, 0.0))
+        pocket = pocket.union(pocket.mirror("XZ"))
+        return pocket.union(pocket.mirror("YZ"))
+
+
+
+
+    def makeCoverPlate (self):
+        """ create the outer metal frame of switch
+        :rtype: ``solid``
+        """
+        # body of cover with button hole completely filled
+        body = cq.Workplane("XY")\
+                    .rect(self.cover_length, self.cover_width).circle(self.button_dia * 0.52)\
+                    .extrude(self.cover_thickness)
+
+        body = self.machineEdges (body, self.cover_width)
+                    #.edges("|Z").chamfer(self.calcChamfer(self.cover_width))
+
+        if not (self.button_type == ButtonType.FLAT and self.terminal_shape.startswith ('TH')):
+            body = body.cut(self.__pocketCoverSide())
+       
+        body = body.translate((0.0, 0.0, self.body_height - self.cover_thickness))
+
+
+
+        return body
+
+    def makeButton (self):
+        """ create the button of switch, depending on button type (flat or projected)
+        :rtype: ``solid``
+        """
+        if self.button_type == ButtonType.RIBS:
+            # TODO: Button RIBS 
+            x = x
+
+        else:
+            return cqMakerTactSwitch.makeButton(self)
+        
+        return body
+
+
+
+
+
+
+        
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*   class parts_cuk_pts125s (partsTactSwitches)                            *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+
+class parts_cuk_pts125s (partsTactSwitches):
+    r"""A class for defining parameter of C&K tactile switches type PTS125S. 
+
+    """
+
+        
+    def getModelVariant (self, modelName):
+        r"""returns the parameter namedtuple from ``all_params`` for the given model name
+        
+        :param modelName: name of the model as defined in ``all_params``
+        :type modelName: ``string``
+        :rtype: ``namedtuple``
+        """
+        return cqMakerCuKPTS125SxTactSwitch (self.all_params[modelName]) 
+
+
+    all_params = {
+
+        'SW_Push_1P1T_NO_CK_PTS125Sx43PSMTR': partsTactSwitches.Params(
+            modelName = 'SW_Push_1P1T_NO_CK_PTS125Sx43PSMTR',  
+            body_width = 12.0,		    
+            body_length = 12.0,	       
+            body_height = 3.3,
+            has_pegs = True,
+            pegs_radius = 0.75,
+            pegs_pitch = 9.0,
+            pegs_heigth = 1.5,
+            pin_pitch = 5.0,
+            distance_pinTip_rows = 15.3,
+            pin_width = 1.0,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 7.0,
+            body_height_with_button = 4.3,
+            button_type = ButtonType.FLAT,
+            with_gnd_pin = False,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'blue body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.PTS125S,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+        'SW_Push_1P1T_NO_CK_PTS125Sx85PSMTR': partsTactSwitches.Params(
+            modelName = 'SW_Push_1P1T_NO_CK_PTS125Sx85PSMTR',  
+            body_width = 12.0,		    
+            body_length = 12.0,	       
+            body_height = 3.3,
+            has_pegs = True,
+            pegs_radius = 0.75,
+            pegs_pitch = 9.0,
+            pegs_heigth = 1.5,
+            pin_pitch = 5.0,
+            distance_pinTip_rows = 15.3,
+            pin_width = 1.0,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 7.0,
+            body_height_with_button = 8.5,
+            button_type = ButtonType.FLAT,
+            with_gnd_pin = False,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'blue body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.PTS125S,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+        'SW_Push_1P1T_NO_CK_PTS125Sx73PSMTR': partsTactSwitches.Params(
+            modelName = 'SW_Push_1P1T_NO_CK_PTS125Sx73PSMTR',  
+            body_width = 12.0,		    
+            body_length = 12.0,	       
+            body_height = 3.3,
+            has_pegs = True,
+            pegs_radius = 0.75,
+            pegs_pitch = 9.0,
+            pegs_heigth = 1.5,
+            pin_pitch = 5.0,
+            distance_pinTip_rows = 15.3,
+            pin_width = 1.0,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 7.0,
+            body_height_with_button = 7.3,
+            button_type = ButtonType.PROJ,
+            with_gnd_pin = False,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'blue body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.PTS125S,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+        'SW_Push_1P1T_NO_CK_PTS125Sx43SMTR': partsTactSwitches.Params(
+            modelName = 'SW_Push_1P1T_NO_CK_PTS125Sx43SMTR',  
+            body_width = 12.0,		    
+            body_length = 12.0,	       
+            body_height = 3.3,
+            pin_pitch = 5.0,
+            distance_pinTip_rows = 15.3,
+            pin_width = 1.0,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 7.0,
+            body_height_with_button = 4.3,
+            button_type = ButtonType.FLAT,
+            with_gnd_pin = False,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'blue body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.PTS125S,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+        'SW_Push_1P1T_NO_CK_PTS125Sx85SMTR': partsTactSwitches.Params(
+            modelName = 'SW_Push_1P1T_NO_CK_PTS125Sx85SMTR',  
+            body_width = 12.0,		    
+            body_length = 12.0,	       
+            body_height = 3.3,
+            pin_pitch = 5.0,
+            distance_pinTip_rows = 15.3,
+            pin_width = 1.0,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 7.0,
+            body_height_with_button = 8.5,
+            button_type = ButtonType.FLAT,
+            with_gnd_pin = False,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'blue body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.PTS125S,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+        'SW_Push_1P1T_NO_CK_PTS125Sx73SMTR': partsTactSwitches.Params(
+            modelName = 'SW_Push_1P1T_NO_CK_PTS125Sx73SMTR',  
+            body_width = 12.0,		    
+            body_length = 12.0,	       
+            body_height = 3.3,
+            pin_pitch = 5.0,
+            distance_pinTip_rows = 15.3,
+            pin_width = 1.0,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_dia = 7.0,
+            body_height_with_button = 7.3,
+            button_type = ButtonType.PROJ,
+            with_gnd_pin = False,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'blue body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.PTS125S,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+
+        'SW_PUSH-12mm': partsTactSwitches.Params(
+            modelName = 'SW_PUSH-12mm',  
+            body_width = 12.0,		    
+            body_length = 12.0,	       
+            body_height = 3.3,
+            pin_pitch = 5.0,
+            distance_pinTip_rows = 12.5,
+            pin_width = 1.0,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.THL,
+            pin_length_below_body = 3.5,
+            button_dia = 7.0,
+            body_height_with_button = 7.3,
+            button_type = ButtonType.PROJ,
+            with_gnd_pin = False,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'blue body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.PTS125S,
+            destination_dir = 'Button_Switch_THT.3dshapes',    
+            ),
+
+
+        'SW_PUSH-12mm_Wuerth-430476085716': partsTactSwitches.Params(
+            modelName = 'SW_PUSH-12mm_Wuerth-430476085716',  
+            body_width = 12.0,		    
+            body_length = 12.0,	       
+            body_height = 3.5,
+            pin_pitch = 5.0,
+            distance_pinTip_rows = 12.5,
+            pin_width = 1.0,
+            pin_thickness = 0.3,
+            terminal_shape = ShapeOfTerminal.THL,
+            pin_length_below_body = 3.5,
+            button_dia = 7.0,
+            body_height_with_button = 8.5,
+            button_type = ButtonType.FLAT,
+            with_gnd_pin = False,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'blue body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.WS_TATV,
+            destination_dir = 'Button_Switch_THT.3dshapes',    
+            ),
+
+    }
+
+

--- a/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_cuk_pts810x.py
+++ b/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_cuk_pts810x.py
@@ -1,0 +1,280 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# This script is derived from a script for generating  DIP_parts and Buzzer_Beeper scripts
+#
+# Dimensions are from data sheets given in the settings of the corresponding KiCad footprint:
+
+## requirements
+## cadquery FreeCAD plugin
+##   https://github.com/jmwright/cadquery-freecad-module
+
+## to run the script just do: freecad main_generator.py modelName
+## e.g. c:\freecad\bin\freecad main_generator.py *b3fs*
+
+## to run the script just do: freecad main_generator.py modelName
+## e.g. c:\freecad\bin\freecad main_generator.py *b3fs*
+
+## the script will generate STEP and VRML parametric models
+## to be used with kicad StepUp script
+
+#* These are a FreeCAD & cadquery tools                                     *
+#* to export generated models in STEP & VRML format.                        *
+#*                                                                          *
+#* cadquery script for generating QFP/SOIC/SSOP/TSSOP models in STEP AP214  *
+#*   Copyright (c) 2015                                                     *
+#* Maurice https://launchpad.net/~easyw                                     *
+#* All trademarks within this guide belong to their legitimate owners.      *
+#*                                                                          *
+#*   Copyright (c) 2020                                                     *
+#* Mountyrox   https://github.com/mountyrox                                 *
+#*                                                                          *
+#*   This program is free software; you can redistribute it and/or modify   *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)     *
+#*   as published by the Free Software Foundation; either version 2 of      *
+#*   the License, or (at your option) any later version.                    *
+#*   for detail see the LICENCE text file.                                  *
+#*                                                                          *
+#*   This program is distributed in the hope that it will be useful,        *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+#*   GNU Library General Public License for more details.                   *
+#*                                                                          *
+#*   You should have received a copy of the GNU Library General Public      *
+#*   License along with this program; if not, write to the Free Software    *
+#*   Foundation, Inc.,                                                      *
+#*   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA           *
+#*                                                                          *
+#****************************************************************************
+import operator
+
+import cadquery as cq
+from Helpers import show
+
+import FreeCAD, Draft, FreeCADGui
+import ImportGui
+import FreeCADGui as Gui
+
+import shaderColors
+import exportPartToVRML as expVRML
+
+# Import cad_tools
+import cq_cad_tools
+# Reload tools
+from cq_cad_tools import reload_lib
+reload_lib(cq_cad_tools)
+# Explicitly load all needed functions
+from cq_cad_tools import FuseObjs_wColors, GetListOfObjects, z_RotateObject, Color_Objects, restore_Main_Tools, exportSTEP, saveFCdoc
+
+import cq_parameters  # modules parameters
+from cq_parameters import ShapeOfTerminal, ButtonType, partParamsTactSwitches
+
+import collections
+from collections import namedtuple
+
+
+from  cq_base_model import PartBase, Polyline  # modules parameters
+
+from cq_base_tact_switches import cqMakerTactSwitch, TactSwitchSeries, partsTactSwitches
+from cq_cuk_kmr2x import cqMakerCuK_Kmr2xTactSwitch, TactSwitchSeries, parts_cuk_kmr2 
+
+
+
+
+class TactSwitchSeries (TactSwitchSeries):
+    r"""A class for holding C&K tactile switch series PTS810x
+
+    .. note:: will be changed to enum when Python version allows it
+    """
+    PTS810 = 'PTS810'
+    r"""PTS810: Microminiature SMT Top Actuated
+    """
+    
+
+
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*       class cqMakerCuK_PTS810xTactSwitch (cqMakerCuK_Kmr2xTactSwitch)    *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+
+class cqMakerCuK_PTS810xTactSwitch (cqMakerCuK_Kmr2xTactSwitch):
+    r"""A class for creating a 3D models from C&K type PTS810. The parameter are defined in the class ``parts_cuk_pts810``
+    :param parameter: namedtuple containing the variable parameter for building the different 3D models.
+    :type  parameter: ``partsTactSwitches.Params``
+
+    """
+    
+    def __init__(self, parameter):
+        cqMakerCuK_Kmr2xTactSwitch.__init__(self, parameter)
+        
+        #self. = parameter. if parameter. != None else                              
+
+    def _paramsForPTS810 (self):
+        r"""set the reqired dimensions for tactile switch serie C&K PTS810
+
+        """
+        self.cover_thickness = 0.15
+        self.body_board_distance = 0.0
+
+
+        # J-hook pins with no upper part
+        self.pin_top_length = 0.0
+        self.pin_top_radius = 0.0
+        self.pin_bottom_length = 0.6
+        self.pin_height = 0.5
+
+        self.cover_offset = 1.3
+        self.body_top_chamfer = 1.25
+        # Dimension of metallic cover plate
+        self.offsets = (0.0, 0.0, 0.0)
+
+
+    # Append the series switcher
+    cqMakerTactSwitch._serieSwitcher[TactSwitchSeries.PTS810] = _paramsForPTS810
+
+    def _padsSideCenter (self):
+        r"""generates a body to be placed (central) at the top side of the parts body. These side pads are the fixing elements for the cover clips.
+
+        :rtype: ``solid``
+        """
+        pad = cq.Workplane("XY", origin=(0.0, self.body_width / 2.0 - self.cover_thickness, self.body_height - self.cover_thickness - self.pad_side_height))\
+                    .rect(self.pad_side_length, self.pad_side_width).extrude(self.pad_side_height)\
+                    .edges(">Z").edges(">Y").fillet(self.pad_side_width * 0.99)
+
+        return pad.union(pad.mirror("XZ"))
+
+    
+    def makePlasticCase (self):
+        """ create the plastic body of the tactile switch
+        :rtype: ``solid``
+        """
+        body = cq.Workplane("XY")\
+                 .rect(self.body_length, self.body_width).extrude(self.body_height - self.cover_thickness)
+
+        body = body.edges("|Z").fillet(0.2)
+
+        pocket = cq.Workplane("XY")\
+            .rect(self.body_length, self.body_width).extrude(self.body_height)\
+            .translate((0.0, 0.0, self.cover_offset))\
+            .edges("|Z").chamfer(self.body_top_chamfer)
+
+        body = body.cut(pocket).cut(self.makeCoverPlate()).edges("|Z").fillet(0.05)
+
+        return body
+
+
+
+
+    def makeCoverPlate (self):
+        """ create the outer metal frame of switch
+        :rtype: ``solid``
+        """
+        # body of cover with button hole completely filled
+        body = cq.Workplane("XY")\
+                    .rect(self.body_length, self.body_width)\
+                    .extrude(self.cover_thickness)
+
+        s = cq.StringSyntaxSelector
+
+        body = body.edges("|Z").chamfer(0.6)
+       
+        body = body.translate((0.0, 0.0, self.cover_offset))\
+            .cut(self.makeButton(self.button_oval_length + 0.1, self.button_oval_width + 0.1))
+
+        return body
+
+    def makeButton (self, button_length = None, button_width = None):
+        """ create the button of switch, depending on button type
+        :rtype: ``solid``
+        """
+        if button_length is None:
+            button_length = self.button_oval_length
+
+        if button_width is None:
+            button_width  = self.button_oval_width
+
+        button_height = self.body_height_with_button - self.cover_offset
+        dl = self.button_oval_width - self.button_oval_length
+
+        s = cq.StringSyntaxSelector
+        body = Polyline(cq.Workplane("XY"))\
+            .addMoveTo(button_length / 2.0, -dl / 2.0)\
+            .addRadiusArc(-button_length, 0.0, button_length/2.0)\
+            .addPoint(0.0, dl)\
+            .addRadiusArc(button_length, 0.0, button_length/2.0)\
+            .make().extrude(button_height)\
+            .edges(">Z").fillet(0.1)
+
+
+        #body = body.edges("|Z").fillet(0.2)
+       
+        body = body.translate((0.0, 0.0, self.cover_offset))
+        return body
+
+
+
+
+        
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*     class parts_cuk_pts810 (parts_cuk_kmr2)                              *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+
+class parts_cuk_pts810 (parts_cuk_kmr2):
+    r"""A class for defining parameter of C&K tactile switches type PTS810. 
+
+    """
+        
+    def getModelVariant (self, modelName):
+        r"""returns the parameter namedtuple from ``all_params`` for the given model name
+        
+        :param modelName: name of the model as defined in ``all_params``
+        :type modelName: ``string``
+        :rtype: ``namedtuple``
+        """
+        return cqMakerCuK_PTS810xTactSwitch (self.all_params[modelName])
+
+
+    all_params = {
+
+        'SW_SPST_PTS810': partsTactSwitches.Params(
+            modelName = 'SW_SPST_PTS810',  
+            body_width = 4.2,		    
+            body_length = 3.2,	       
+            body_height = 1.8,
+            pin_pitch = 2.15,
+            distance_pinTip_rows = 4.6,
+            pin_width = 0.55,
+            pin_thickness = 0.1,
+            terminal_shape = ShapeOfTerminal.JH,
+            button_oval_width = 3.0,
+            button_oval_length = 2.2,
+            body_height_with_button = 2.5,
+            button_type = ButtonType.FLAT,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'blue body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.PTS810,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+
+    }
+
+

--- a/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_parameters.py
@@ -1,0 +1,308 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# This is derived from a cadquery script for generating QFP/GullWings models in X3D format.
+#
+# from https://bitbucket.org/hyOzd/freecad-macros
+# author hyOzd
+#
+
+## file of parametric definitions
+
+def reload_lib(lib):
+    if (sys.version_info > (3, 0)):
+        import importlib
+        importlib.reload(lib)
+    else:
+        reload (lib)
+
+
+import collections
+from collections import namedtuple
+
+import FreeCAD, Draft, FreeCADGui
+import ImportGui
+import FreeCADGui as Gui
+
+import shaderColors
+import exportPartToVRML as expVRML
+
+## base parametes & model
+import collections
+from collections import namedtuple
+
+# Import cad_tools
+import cq_cad_tools
+# Reload tools
+from cq_cad_tools import reload_lib
+reload_lib(cq_cad_tools)
+# Explicitly load all needed functions
+from cq_cad_tools import FuseObjs_wColors, GetListOfObjects, restore_Main_Tools, \
+ exportSTEP, close_CQ_Example, exportVRML, saveFCdoc, z_RotateObject, Color_Objects, \
+ CutObjs_wColors, checkRequirements
+
+# Sphinx workaround #1
+try:
+    QtGui
+except NameError:
+    QtGui = None
+#
+
+try:
+    # Gui.SendMsgToActiveView("Run")
+#    from Gui.Command import *
+    Gui.activateWorkbench("CadQueryWorkbench")
+    import cadquery
+    cq = cadquery
+    from Helpers import show
+    # CadQuery Gui
+except: # catch *all* exceptions
+    msg = "missing CadQuery 0.3.0 or later Module!\r\n\r\n"
+    msg += "https://github.com/jmwright/cadquery-freecad-module/wiki\n"
+    if QtGui is not None:
+        reply = QtGui.QMessageBox.information(None,"Info ...",msg)
+    # maui end
+
+#checking requirements
+checkRequirements(cq)
+
+
+class ShapeOfTerminal:
+    r"""A class for holding constants for Shape of terminal of part
+
+    .. note:: will be changed to enum when Python version allows it
+    """
+    JH = 'JH'
+    r"""JH - J-hook
+    """
+    GW = 'GW'
+    r"""GW - Gull wing
+    """
+    TH = 'TH'
+    r"""TH - Through hole pin
+    """
+    THC = 'THC'
+    r"""THC - angled THT pin with asymetrical clamping bend 
+    """
+    THL = 'THL'
+    r"""THL - angled THT pin with symetrical lambda shaped clamping bend 
+    """
+
+class ButtonType:
+    r"""A class for holding type of button of Omron tactile switch series
+
+    .. note:: will be changed to enum when Python version allows it
+    """
+    FLAT = 'FLAT'
+    r"""FLAT: Normal round button
+    """
+    PROJ = 'PROJ'
+    r"""PROJ: Projected type (round knob on square shaft)
+    """
+
+class ButtonRing:
+    r"""A class defining the type of an additional ring around the button.
+
+    .. note:: will be changed to enum when Python version allows it
+    """
+    NONE = 'NONE'
+    r"""NONE: No additional button 
+    """
+    ROUND = 'ROUND'
+    r"""ROUND: Round button ring
+    """
+    OCTA = 'OCTA'
+    r"""OCTA: Octagon button ring
+    """
+
+
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+
+class partParamsTactSwitches ():
+    r"""Class containing the parameter for building a 3D model of a tactile switch
+
+    :param params: namedtuple containing the variable parameter for building the different 3D models.
+    :type  params: ``partsTactSwitches.Params``
+    """
+
+    def __init__(self, params):
+
+        # get all entries of the params list as dictionary
+        args = params._asdict()
+        self.type = params.type if 'type' in args and params.type != None else "SMD"
+
+        # Defining all dimensions needed to build the model.
+        # If a dimension is part of the given params list, this value must be used
+
+        # Dimensions of plastic body
+        self.body_height = params.body_height if 'body_height' in args and  params.body_height  != None else 3.75
+        self.body_length = params.body_length if 'body_length' in args and  params.body_length  != None else 6.6  # side of part where the pins are
+        self.body_width = params.body_width if 'body_width' in args and  params.body_width  != None else 6.0
+        self.body_height_with_button = params.body_height_with_button if 'body_height_with_button' in args and  params.body_height_with_button  != None else 5.0
+        # if no distance of body to board is given with params it is set to None and will be set depending on shape of terminals 
+        self.body_board_distance = params.body_board_distance if 'body_board_distance' in args and  params.body_board_distance  != None else None
+        # if case has alignment pegs 'has_pegs' must be true
+        self.has_pegs = params.has_pegs if 'has_pegs' in args and  params.has_pegs  != None else False
+        self.pegs_pitch = params.pegs_pitch if 'pegs_pitch' in args and  params.pegs_pitch  != None else 9.0
+        self.pegs_radius = params.pegs_radius if 'pegs_radius' in args and  params.pegs_radius  != None else 1.0
+        self.pegs_heigth = params.pegs_heigth if 'pegs_heigth' in args and  params.pegs_heigth  != None else 1.5
+        
+        # Dimesion of button
+        self.button_dia = params.button_dia if 'button_dia' in args and  params.button_dia  != None else 3.5
+        self.button_ring = params.button_ring if 'button_ring' in args and  params.button_ring  != None else ButtonRing.NONE
+        self.button_ring_radius = params.button_ring_radius if 'button_ring_radius' in args and  params.button_ring_radius  != None else 2.35
+        self.button_ring_heigth = params.button_ring_heigth if 'button_ring_heigth' in args and  params.button_ring_heigth  != None else 1.6
+        self.button_ring_length = params.button_ring_length if 'button_ring_length' in args and  params.button_ring_length  != None else 3.7
+        self.button_ring_width = params.button_ring_width if 'button_ring_width' in args and  params.button_ring_width  != None else 3.7
+
+        # dimension of pins
+        self.num_pins = params.num_pins if 'num_pins' in args and  params.num_pins  != None else 4
+        self.pin_pitch = params.pin_pitch if 'pin_pitch' in args and  params.pin_pitch  != None else 2.54
+        self.pin_width = params.pin_width if 'pin_width' in args and  params.pin_width  != None else 0.6
+        self.pin_thickness = params.pin_thickness if 'pin_thickness' in args and  params.pin_thickness  != None else 0.2
+        self.distance_pinTip_rows = params.distance_pinTip_rows if 'distance_pinTip_rows' in args and  params.distance_pinTip_rows  != None else 10.0  # distance from tip of pin from row one to row two
+        self.num_pin_rows = params.num_pin_rows if 'num_pin_rows' in args and  params.num_pin_rows  != None else 2
+        self.top_length = params.top_length if 'top_length' in args and  params.top_length  != None else 0.2         # only used for J-hook and angled THT pin
+        self.pin_length_below_body = params.pin_length_below_body if 'pin_length_below_body' in args and  params.pin_length_below_body  != None else 3.5         # only used for THT pin
+
+        # Model variants
+        self.terminal_shape = params.terminal_shape if 'terminal_shape' in args and  params.terminal_shape  != None else ShapeOfTerminal.GW
+        
+        
+        # Default dimensions. These dimensions Will normally be defined in the serie specific derived class
+        # Dimensions of pockest at bottom of plastic body
+        self.bottom_pocket_depth = 0.1
+        self.pin_pocket_edge_length =  1.6
+        self.pin_pocket_mid_length =  1.2
+        self.pin_pocket_edge_width =  1.3
+
+        # Dimension of metallic cover plate
+        self.cover_thickness = params.cover_thickness if 'cover_thickness' in args and  params.cover_thickness  != None else 0.3
+        self.cover_side_height =  2.1
+        self.cover_plate_with_side_sheets = False  # must be true if cover of switch has side clips
+        # for side sheets with center pocket:
+        self.cover_side_pocket_width = 4.0
+        self.cover_side_pocket_heigth = 1.3
+        # for solid side sheets:
+        self.cover_solid_side_width =  self.body_width / 2.0
+
+
+        self.button_has_base_plate = False;
+#self. = params. if '' in args and  params.  != None else 
+
+
+        # Dimensions of pockest at top of plastic body
+        # self.pocket_turn_inset_top_depth: see derived dimensions
+        self.pocket_top_side_width =  0.45
+        self.pocket_top_side_depth =  0.45
+
+        # Dimensions of plastic body side pads
+        self.pad_side_height =  self.cover_side_pocket_heigth 
+        self.pad_side_width =  self.cover_side_pocket_width
+         
+        # derived dimensions. Some depend on cover thickness. If cover thickness must be changed by a in derived classes,
+        # these dimensions have to be adapted to the new thickness. 
+        self.button_height = self.body_height_with_button - self.body_height + self.cover_thickness   # the button heigth is measured from below cover to top
+        self.body_height_plastic = self.body_height - self.cover_thickness
+        self.pad_side_length =  self.cover_thickness 
+        # for some switches the lower part of the side clamps are not closed (Omron B3S). For these models the following parameter must be > 0.0
+        self.button_hole_dia = self.button_dia * 1.04
+        
+        # for projected button type some more dimensions are needed
+        self.button_proj_length_top = self.button_dia / 1.42  # sqrt (2)
+        self.button_proj_length_mid = self.button_proj_length_top / 1.42  # sqrt (2)
+        self.button_proj_hight_bot = self.button_height / 4.0
+        self.button_proj_hight_mid = self.button_height / 4.0
+        self.button_proj_hight_top = self.button_height / 2.0
+
+        # Call of function defining dimensions depending on the shape of terminals
+        paramFunction = self._TerminalShapeSwitcher.get(self.terminal_shape, None)
+        if paramFunction == None:     # not a valid terminal_shape
+            FreeCAD.Console.PrintMessage(str(self.terminal_shape) + ' not a valid member of ' + str(ShapeOfTerminal))
+            self.make_me = False
+        else:  # Call the funktion
+            paramFunction (self)
+
+
+    def paramsForJh (self):
+        r"""set the reqired dimensions for building J-hook pins
+
+        """
+        self.pin_bottom_length =  1.0 
+        self.pin_height = 1.2
+        self.pin_top_length = 1.0
+        self.pin_top_radius = self.pin_thickness / 2.0  # inner radius at top of j-hook pin
+        if self.body_board_distance is None:
+            self.body_board_distance = max (self.pin_thickness  - self.bottom_pocket_depth, 0.0)
+        self.first_pin_pos = (self.pin_pitch * (self.num_pins / 2.0 / self.num_pin_rows - 0.5), self.distance_pinTip_rows/2.0 - self.pin_thickness)
+        self.rotation = 90.0
+        self.offsets = (0.0, 0.0, 0.0)
+
+    def paramsForGw (self):
+        r"""set the reqired dimensions for building gullwing pins
+
+        """
+        self.pin_bottom_length =  1.3
+        self.pin_height = 0.7
+        if self.body_board_distance is None:
+            self.body_board_distance = 0.0
+        # Sice the pins are hidden inside the body, we can make the pin length half the distance pin tip of both rows (distance_pinTip_rows)
+        # In this case the y- part of the first pin pos can be 0.0
+        self.pin_length = self.distance_pinTip_rows / 2.0         # only used for gullwing
+        self.first_pin_pos = (self.pin_pitch * (self.num_pins / 2.0 / self.num_pin_rows - 0.5), 0.0)
+        self.rotation = 90.0
+        self.offsets = (0.0, 0.0, 0.0)
+
+    def paramsForTh (self):
+        r"""set the reqired dimensions for building through hole pins
+
+        """
+        self.pin_height = self.pin_length_below_body + 1.1
+        if self.body_board_distance is None:
+            self.body_board_distance = 0.0
+        # Sice the pins are hidden inside the body, we can make the pin top length half the distance pin tip of both rows (distance_pinTip_rows)
+        # In this case the y- part of the first pin pos can be 0.0
+        self.pin_top_length = self.distance_pinTip_rows / 2.0 - self.pin_thickness  
+        self.first_pin_pos = (self.pin_pitch * (self.num_pins / 2.0 / self.num_pin_rows - 0.5), 0.0)
+        # THT pins must be shifted upwards 
+        self.pin_z_shift = self.pin_height - self.pin_thickness/2.0 - self.pin_length_below_body  
+        self.rotation = 90.0
+        offsetX = (self.distance_pinTip_rows / 2.0)
+        offsetY = (-self.first_pin_pos[0])
+        self.offsets = (offsetX, offsetY, 0.0)
+
+
+    # dictionary assigning the parameter functions for setting the pin dimensions to ShapeOfTerminal keys
+    _TerminalShapeSwitcher = {
+        ShapeOfTerminal.GW: paramsForGw,
+        ShapeOfTerminal.JH: paramsForJh,
+        ShapeOfTerminal.TH: paramsForTh,
+        ShapeOfTerminal.THC: paramsForTh,
+        ShapeOfTerminal.THL: paramsForTh,
+        }
+
+
+

--- a/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_ultra_small_tact_switch.py
+++ b/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_ultra_small_tact_switch.py
@@ -1,0 +1,675 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# This script is derived from a script for generating  DIP_parts and Buzzer_Beeper scripts
+#
+# Dimensions are from data sheets given in the settings of the corresponding KiCad footprint:
+
+## requirements
+## cadquery FreeCAD plugin
+##   https://github.com/jmwright/cadquery-freecad-module
+
+## to run the script just do: freecad main_generator.py modelName
+## e.g. c:\freecad\bin\freecad main_generator.py *b3fs*
+
+## to run the script just do: freecad main_generator.py modelName
+## e.g. c:\freecad\bin\freecad main_generator.py *b3fs*
+
+## the script will generate STEP and VRML parametric models
+## to be used with kicad StepUp script
+
+#* These are a FreeCAD & cadquery tools                                     *
+#* to export generated models in STEP & VRML format.                        *
+#*                                                                          *
+#* cadquery script for generating QFP/SOIC/SSOP/TSSOP models in STEP AP214  *
+#*   Copyright (c) 2015                                                     *
+#* Maurice https://launchpad.net/~easyw                                     *
+#* All trademarks within this guide belong to their legitimate owners.      *
+#*                                                                          *
+#*   Copyright (c) 2020                                                     *
+#* Mountyrox   https://github.com/mountyrox                                 *
+#*                                                                          *
+#*   This program is free software; you can redistribute it and/or modify   *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)     *
+#*   as published by the Free Software Foundation; either version 2 of      *
+#*   the License, or (at your option) any later version.                    *
+#*   for detail see the LICENCE text file.                                  *
+#*                                                                          *
+#*   This program is distributed in the hope that it will be useful,        *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+#*   GNU Library General Public License for more details.                   *
+#*                                                                          *
+#*   You should have received a copy of the GNU Library General Public      *
+#*   License along with this program; if not, write to the Free Software    *
+#*   Foundation, Inc.,                                                      *
+#*   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA           *
+#*                                                                          *
+#****************************************************************************
+import operator
+
+import cadquery as cq
+from Helpers import show
+
+import FreeCAD, Draft, FreeCADGui
+import ImportGui
+import FreeCADGui as Gui
+
+import shaderColors
+import exportPartToVRML as expVRML
+
+# Import cad_tools
+import cq_cad_tools
+# Reload tools
+from cq_cad_tools import reload_lib
+reload_lib(cq_cad_tools)
+# Explicitly load all needed functions
+from cq_cad_tools import FuseObjs_wColors, GetListOfObjects, z_RotateObject, Color_Objects, restore_Main_Tools, exportSTEP, saveFCdoc
+
+import cq_parameters  # modules parameters
+from cq_parameters import ShapeOfTerminal, ButtonType, partParamsTactSwitches
+import collections
+from collections import namedtuple
+
+
+from  cq_base_model import PartBase, Polyline  # modules parameters
+
+from cq_base_tact_switches import cqMakerTactSwitch, TactSwitchSeries, partsTactSwitches
+
+
+class ButtonType (ButtonType):
+    r"""A class for holding type of button of Omron tactile switch series
+
+    .. note:: will be changed to enum when Python version allows it
+    """
+    SIDE_D = 'SIDE_D'
+    r"""SIDE_D: Side operational button in D shape (Omron 3BU)
+    """
+    SIDE_T = 'SIDE_T'
+    r"""SIDE_T: Side operational button in T shape (Panasonic EVQPU)
+    """
+
+
+class TactSwitchSeries (TactSwitchSeries):
+    r"""A class for holding C&K tactile switch series PTS125Sx
+
+    .. note:: will be changed to enum when Python version allows it
+    """
+    EVQPU = 'EVQPU'
+    r"""EVQPU: Small-sized Side-operational SMD from Panasonic
+    """
+    EVQP7 = 'EVQP7'
+    r"""EVQP7: 3.5 mm × 2.9 mm Side-operational SMD from Panasonic
+    """
+    B3U3 = 'B3U3'
+    r"""B3U: Ultra-small Surface-mounting side actuated Tactile from Omron. 
+    """
+    
+
+
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*   class cqMakerUltraSmallTactSwitch (cqMakerTactSwitch)                  *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+
+class cqMakerUltraSmallTactSwitch (cqMakerTactSwitch):
+    r"""A class for creating a 3D models from C&K type PTS125S and Wuerth TATV. The parameter are defined in the class ``parts_cuk_pts125s``
+    :param parameter: namedtuple containing the variable parameter for building the different 3D models.
+    :type  parameter: ``partsTactSwitches.Params``
+
+    """
+    
+    def __init__(self, parameter):
+        cqMakerTactSwitch.__init__(self, parameter)
+        
+        self.button_side_width = parameter.button_side_width if parameter.button_side_width != None else 2.6                        
+        self.button_side_height = parameter.button_side_height if parameter.button_side_height != None else 1.4                             
+        self.body_length_with_button = parameter.body_length_with_button if parameter.body_length_with_button != None else 4.5                             
+        #self. = parameter. if parameter. != None else                              
+        
+        self.pad_bottom_height = 0.3
+        self.button_hole_dia = 1.5
+
+        self.bottom_pocket_depth = 0.1
+        self.pin_pocket_edge_length =  0.95
+        self.pin_pocket_edge_width =  0.4
+
+        # new cover thickness requires new calculation of body_height_plastic and pad_side_length   
+        self.cover_thickness = 0.15   
+        self.body_height_plastic = self.body_height - self.cover_thickness
+        self.pad_side_length =  self.cover_thickness 
+
+        paramFunction = cqMakerTactSwitch._serieSwitcher.get(self.serie, None)
+        if paramFunction == None:     # not a valid terminal_shape
+            FreeCAD.Console.PrintMessage(str(self.serie) + ' not a valid member of ' + str(TactSwitchSeries))
+            self.make_me = False
+        else:  # Call the funktion
+            paramFunction (self)
+
+
+    def _paramsForEVQPU (self):
+        r"""set the reqired dimensions for tactile switch serie Panasonic EVQPU
+
+        """
+        self.cover_plate_with_side_sheets = True # cover side sheet has T-shape, plate height and pad size has to be defined 
+        self.cover_side_height = self.body_height - 0.1
+        self.pad_side_height = 0.77
+        self.pad_side_width = 0.77
+        
+        self.cover_plate_with_pin_side_sheets = True
+        self.cover_pin_side_sheet_width = 0.6
+        self.cover_pin_side_sheet_height = 0.8
+                
+        # J-hook pins with no upper part
+        self.pin_top_length = 0.0
+        self.pin_top_radius = 0.0
+        self.pin_height = 0.6
+
+        if self.terminal_shape is ShapeOfTerminal.JH:
+            self.pin_bottom_length = 0.6
+        elif self.terminal_shape is ShapeOfTerminal.GW:
+            self.pin_bottom_length = 1.4
+
+        self.body_board_distance = 0.0
+        # make special pads and cover clips
+        self.body_side_pads = self._padSideEdge
+        self.cover_side_clips = self._coverSideSheets_T_Shape
+
+    def _paramsForEVQP7 (self):
+        r"""set the reqired dimensions for tactile switch serie Panasonic EVQP7
+
+        """
+        self.cover_plate_with_side_sheets = True # cover side sheet has T-shape, plate height and pad size has to be defined 
+        self.cover_side_height =  1.1
+        self.pad_side_height = 0.5
+        self.pad_side_width = 0.4
+        
+        self.cover_plate_with_pin_side_sheets = True
+        self.cover_pin_side_sheet_width = 0.7
+        self.cover_pin_side_sheet_height = 0.7
+                
+        # J-hook pins with no upper part
+        self.pin_top_length = 0.0
+        self.pin_top_radius = 0.0
+        self.pin_height = 0.6
+
+        if self.terminal_shape is ShapeOfTerminal.JH:
+            self.pin_bottom_length = 0.6
+        elif self.terminal_shape is ShapeOfTerminal.GW:
+            self.pin_bottom_length = 1.0
+
+        self.body_board_distance = 0.0
+        # make special pads and cover clips
+        self.body_side_pads = self._padSideEdge
+        self.cover_side_clips = self._coverSideSheets_T_Shape
+        self.rotation = -90.0
+
+        
+    def _paramsForB3U3 (self):
+        r"""set the reqired dimensions for tactile switch serie B3U from Omron
+
+        """
+        # for SMD parts with a ground terminal an additional offset is necessary, because the center of the footprints is always in the center of all pins
+        self.offsets = (0.0, 0.82, 0.0) if self.with_gnd_pin else (0.0, 0.0, 0.0)
+
+        self.cover_plate_with_side_sheets = True # cover side sheet has T-shape, plate height and pad size has to be defined 
+        self.cover_side_height =  0.9
+        self.pad_side_height = 0.55
+        self.pad_side_width = 0.3
+
+        self.pin_pocket_edge_length =  self.cover_thickness
+        self.pin_pocket_edge_width =  self.cover_thickness
+
+        self.cover_plate_with_pin_side_sheets = False
+
+        # new cover thickness requires new calculation of body_height_plastic and pad_side_length   
+        self.cover_thickness = 0.15   
+        self.body_height_plastic = self.body_height - self.cover_thickness
+        self.pad_side_length =  self.cover_thickness 
+                
+        self.pin_bottom_length = 0.8
+                
+        # J-hook pins with no upper part
+        #self.pin_top_length = 0.0
+        #self.pin_top_radius = 0.0
+        #self.pin_height = 0.6
+
+        if self.terminal_shape is ShapeOfTerminal.JH:
+            self.pin_bottom_length = 0.6
+        elif self.terminal_shape is ShapeOfTerminal.GW:
+            self.pin_bottom_length = 0.8
+
+        self.body_board_distance = 0.0
+        # make special pads and cover clips
+        self.body_side_pads = self._padSideEdge
+        self.cover_side_clips = self._coverSideSheets_T_Shape
+
+
+    # Append the series switcher
+    cqMakerTactSwitch._serieSwitcher[TactSwitchSeries.B3U3] = _paramsForB3U3  
+    cqMakerTactSwitch._serieSwitcher[TactSwitchSeries.EVQPU] = _paramsForEVQPU  
+    cqMakerTactSwitch._serieSwitcher[TactSwitchSeries.EVQP7] = _paramsForEVQP7  
+
+
+
+
+
+    def __centralSidePads (self):
+        r"""generates a body to be placed (central) at the top side of the parts body. These side pads are the fixing elements for the cover clips.
+
+        :rtype: ``solid``
+        """
+        body_length_without_pads = self.body_length - 2.0 * self.pad_side_length
+        h = self.body_height + self.cover_side_height / 2.0 - (self.pad_side_height + self.cover_thickness) * 1.5
+        body = cq.Workplane("YZ").workplane(offset=body_length_without_pads / 2.0)\
+                 .rect(self.body_width - 3.0 * self.pad_side_width, h).extrude(self.cover_thickness)\
+                 .translate ((0.0, 0.0, h / 2.0))
+
+        return body.union(body.mirror("YZ"))
+
+
+    def makePlasticCase (self):
+        body = cqMakerTactSwitch.makePlasticCase (self)
+        return body.union(self.__centralSidePads())
+
+
+    def _coverCentralHole(self):
+        """ create a body to cut a central square hole into cover
+        :rtype: ``solid``
+        """
+        body = cq.Workplane("XY").rect(1.0, 1.0).extrude(self.cover_thickness)
+        return body
+
+
+    def _coverFilletCentralHole(self, body):
+        """ fillet edges of central rectangle hole in cover
+        :param body: The body with hole to fillet 
+        :type body: ``solid``
+        :rtype: ``solid``
+        """
+        s = cq.StringSyntaxSelector
+        body = body.edges(s(">Z")-s(">Y")-s("<Y")-s("<X")-s(">X")).fillet(self.cover_thickness*0.25)
+        return body.edges("|Z").fillet(0.1)
+
+    
+    def _makeSideBottomD (self):
+        # length, width, height of pusher head
+        l_ph = 0.5
+        w_ph = self.button_side_width
+        h_ph = self.button_side_height
+        # length, width, height of guide pusher
+        l_gp = self.body_length_with_button - self.body_length / 2.0 - l_ph
+        w_gp = w_ph - 0.2
+        h_gp = h_ph * 0.43
+        #.workplane(offset=self.body_height_plastic)\
+        body_gp = cq.Workplane("XY")\
+                    .rect(l_gp, w_gp).extrude(h_gp)
+
+        pocket = cq.Workplane("XY")\
+                    .rect(l_gp, 0.3).extrude(h_gp).translate ((0.0, 0.4, h_gp / 2.0))
+
+        body_gp = body_gp.cut(pocket)
+        body_gp = body_gp.cut(pocket.translate ((0.0, -2.0*0.4, 0.0)))
+#l_ph * 0.99)\
+        body_ph = cq.Workplane("XY")\
+                    .rect(l_ph, w_ph).extrude(-h_ph)\
+                    .edges(">X").edges("|Z").chamfer(l_ph * 0.90)\
+                    .translate (((l_gp + l_ph) /2.0, 0.0, h_gp + self.cover_thickness))
+
+        body = body_gp.union(body_ph).edges().fillet(0.02)
+
+        return body.translate((l_gp/2.0, 0.0, self.body_height_plastic - h_gp))
+
+
+    
+    def _makeSideBottomT (self):
+        # length, width, height of pusher head
+        l_ph = 0.5
+        w_ph = self.button_side_width
+        h_ph = self.button_side_height
+        # length, width, height of guide pusher
+        l_gp = self.body_length_with_button - self.body_length / 2.0 - l_ph
+        w_gp = w_ph - 0.2
+        h_gp = h_ph * 0.43
+        #.workplane(offset=self.body_height_plastic)\
+        body_gp = cq.Workplane("XY")\
+                    .rect(l_gp, w_gp).extrude(h_gp)
+
+        pocket = cq.Workplane("XY")\
+                    .rect(l_gp, 0.3).extrude(h_gp).translate ((0.0, 0.4, h_gp / 2.0))
+
+        body_gp = body_gp.cut(pocket)
+        body_gp = body_gp.cut(pocket.translate ((0.0, -2.0*0.4, 0.0)))
+
+        body_ph = cq.Workplane("XY")\
+                    .rect(l_ph, w_ph).extrude(-h_ph)\
+                    .translate (((l_gp + l_ph) /2.0, 0.0, h_gp + self.cover_thickness))
+
+        body = body_gp.union(body_ph).edges().fillet(0.02)
+            
+
+        return body.translate((l_gp/2.0, 0.0, self.body_height_plastic - h_gp))
+    
+
+    def makeButton (self):
+        """ create the button of switch, depending on button type (flat or projected)
+        :rtype: ``solid``
+        """
+        if self.button_type is ButtonType.SIDE_D:
+            # TODO: Button RIBS 
+            return self._makeSideBottomD()
+
+        elif self.button_type is ButtonType.SIDE_T:
+            return self._makeSideBottomT()
+         
+        else:
+            return cqMakerTactSwitch.makeButton(self)
+        
+        return body
+
+        
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+#*                                                                          *
+
+class partsUltraSmallTactSwitches (partsTactSwitches):
+    r"""A class for defining parameter of ultra small tactile switches type Omron B3U and Panasonic EVQPU & EVQP7. 
+
+    """
+
+        
+    def getModelVariant (self, modelName):
+        r"""returns the parameter namedtuple from ``all_params`` for the given model name
+        
+        :param modelName: name of the model as defined in ``all_params``
+        :type modelName: ``string``
+        :rtype: ``namedtuple``
+        """
+        return cqMakerUltraSmallTactSwitch (self.all_params[modelName])
+    
+    # will be used if Python version allows it
+    #try:
+    #    # extend the ParamsWithDefault named tuple by 'point'
+    #    partsTactSwitches.Params = partsTactSwitches.namedtuple_with_defaults('Params',partsTactSwitches.Params.\
+    #        _fields+('button_side_width', 'button_side_height', 'body_length_with_button'))
+    #except:
+    #    FreeCAD.Console.PrintMessage('invalid or duplicate field names.\r\n')
+
+
+
+    all_params = {
+
+        'Panasonic_EVQPUJ_EVQPUA': partsTactSwitches.Params(
+            modelName = 'Panasonic_EVQPUJ_EVQPUA',  
+            body_width = 4.7,		    
+            body_length = 3.5,	       
+            body_height = 1.65,
+            pin_pitch = 1.7,
+            distance_pinTip_rows = 6.4,
+            pin_width = 0.6,
+            pin_thickness = 0.2,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_side_width = 2.6,
+            button_side_height = 1.4,
+            body_length_with_button = 4.5,
+            button_type = ButtonType.SIDE_T,
+            with_gnd_pin = False,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.EVQPU,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+        'Panasonic_EVQPUK_EVQPUB': partsTactSwitches.Params(
+            modelName = 'Panasonic_EVQPUK_EVQPUB',  
+            body_width = 4.7,		    
+            body_length = 3.5,	       
+            body_height = 1.65,
+            pin_pitch = 1.7,
+            distance_pinTip_rows = 5.5,
+            pin_width = 0.6,
+            pin_thickness = 0.2,
+            terminal_shape = ShapeOfTerminal.JH,
+            button_side_width = 2.6,
+            button_side_height = 1.4,
+            body_length_with_button = 4.5,
+            button_type = ButtonType.SIDE_T,
+            with_gnd_pin = False,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.EVQPU,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+        'Panasonic_EVQPUL_EVQPUC': partsTactSwitches.Params(
+            modelName = 'Panasonic_EVQPUL_EVQPUC',  
+            body_width = 4.7,		    
+            body_length = 3.5,	       
+            body_height = 1.65,
+            pin_pitch = 1.7,
+            distance_pinTip_rows = 6.4,
+            pin_width = 0.6,
+            pin_thickness = 0.2,
+            has_pegs = True,
+            pegs_radius = 0.65/2.0,
+            pegs_pitch = 2.75,
+            pegs_heigth = 0.5,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_side_width = 2.6,
+            button_side_height = 1.4,
+            body_length_with_button = 4.5,
+            button_type = ButtonType.SIDE_T,
+            with_gnd_pin = False,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.EVQPU,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+        'Panasonic_EVQPUM_EVQPUD': partsTactSwitches.Params(
+            modelName = 'Panasonic_EVQPUM_EVQPUD',  
+            body_width = 4.7,		    
+            body_length = 3.5,	       
+            body_height = 1.65,
+            pin_pitch = 1.7,
+            distance_pinTip_rows = 5.5,
+            pin_width = 0.6,
+            pin_thickness = 0.2,
+            has_pegs = True,
+            pegs_radius = 0.65/2.0,
+            pegs_pitch = 2.75,
+            pegs_heigth = 0.5,
+            terminal_shape = ShapeOfTerminal.JH,
+            button_side_width = 2.6,
+            button_side_height = 1.4,
+            body_length_with_button = 4.5,
+            button_type = ButtonType.SIDE_T,
+            with_gnd_pin = False,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.EVQPU,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+        'SW_SPST_EVQP7A': partsTactSwitches.Params(
+            modelName = 'SW_SPST_EVQP7A',  
+            body_width = 3.5,		    
+            body_length = 2.9,	       
+            body_height = 1.35,
+            pin_pitch = 1.48,
+            distance_pinTip_rows = 4.7,
+            pin_width = 0.62,
+            pin_thickness = 0.2,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_side_width = 1.7,
+            button_side_height = 1.1,
+            body_length_with_button = 3.55,
+            button_type = ButtonType.SIDE_T,
+            with_gnd_pin = False,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.EVQP7,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+
+        'SW_SPST_EVQP7C': partsTactSwitches.Params(
+            modelName = 'SW_SPST_EVQP7C',  
+            body_width = 3.5,		    
+            body_length = 2.9,	       
+            body_height = 1.35,
+            pin_pitch = 1.48,
+            distance_pinTip_rows = 4.7,
+            pin_width = 0.62,
+            pin_thickness = 0.2,
+            has_pegs = True,
+            pegs_radius = 0.65/2.0,
+            pegs_pitch = 1.8,
+            pegs_heigth = 0.5,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_side_width = 1.7,
+            button_side_height = 1.1,
+            body_length_with_button = 3.55,
+            button_type = ButtonType.SIDE_T,
+            with_gnd_pin = False,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.EVQP7,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+
+
+        'SW_SPST_B3U-3000P-B': partsTactSwitches.Params(
+            modelName = 'SW_SPST_B3U-3000P-B',  
+            body_width = 3.0,		    
+            body_length = 2.5,	       
+            body_height = 1.2,
+            pin_pitch = 0.0,
+            distance_pinTip_rows = 4.0,
+            pin_width = 1.4,
+            pin_thickness = 0.2,
+            has_pegs = True,
+            pegs_radius = 0.65/2.0,
+            pegs_pitch = 0.0,
+            pegs_heigth = 0.5,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_side_width = 1.7,
+            button_side_height = 1.2,
+            body_length_with_button = 3.2,
+            button_type = ButtonType.SIDE_D,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3U3,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+
+        'SW_SPST_B3U-3000P': partsTactSwitches.Params(
+            modelName = 'SW_SPST_B3U-3000P',  
+            body_width = 3.0,		    
+            body_length = 2.5,	       
+            body_height = 1.2,
+            pin_pitch = 0.0,
+            distance_pinTip_rows = 4.0,
+            pin_width = 1.4,
+            pin_thickness = 0.2,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_side_width = 1.7,
+            button_side_height = 1.2,
+            body_length_with_button = 3.2,
+            button_type = ButtonType.SIDE_D,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3U3,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+
+        'SW_SPST_B3U-3100P-B': partsTactSwitches.Params(
+            modelName = 'SW_SPST_B3U-3100P-B',  
+            body_width = 3.0,		    
+            body_length = 2.5,	       
+            body_height = 1.2,
+            pin_pitch = 0.0,
+            distance_pinTip_rows = 4.0,
+            pin_width = 1.4,
+            pin_thickness = 0.2,
+            has_pegs = True,
+            pegs_radius = 0.65/2.0,
+            pegs_pitch = 0.0,
+            pegs_heigth = 0.5,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_side_width = 1.7,
+            button_side_height = 1.2,
+            body_length_with_button = 3.2,
+            button_type = ButtonType.SIDE_D,
+            with_gnd_pin = True,
+            gnd_pin_tip_to_center = 1.9,
+            gnd_pin_width = 0.5,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3U3,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+
+        'SW_SPST_B3U-3100P': partsTactSwitches.Params(
+            modelName = 'SW_SPST_B3U-3100P',  
+            body_width = 3.0,		    
+            body_length = 2.5,	       
+            body_height = 1.2,
+            pin_pitch = 0.0,
+            distance_pinTip_rows = 4.0,
+            pin_width = 1.4,
+            pin_thickness = 0.2,
+            terminal_shape = ShapeOfTerminal.GW,
+            button_side_width = 1.7,
+            button_side_height = 1.2,
+            body_length_with_button = 3.2,
+            button_type = ButtonType.SIDE_D,
+            with_gnd_pin = True,
+            gnd_pin_tip_to_center = 1.9,
+            gnd_pin_width = 0.5,
+            cover_color_key = 'metal grey pins',        
+            body_color_key = 'black body',        
+            button_color_key = 'black body',        
+            pin_color_key = 'metal silver',  
+            serie = TactSwitchSeries.B3U3,
+            destination_dir = 'Button_Switch_SMD.3dshapes',    
+            ),
+
+
+    }
+
+

--- a/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/main_generator.py
+++ b/cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/main_generator.py
@@ -1,0 +1,317 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+
+
+#****************************************************************************
+#*                                                                          *
+#* scripts for generating generic parameters for tactile switches different *
+#* types: Omron, C&K, Alps, Panasonic, Wuerth, etc.                         *
+#*                                                                          *
+#* This is part of FreeCAD & cadquery tools                                 *
+#* to export generated models in STEP & VRML format.                        *
+#*   Copyright (c) 2020                                                     *
+#* Mountyrox   https://github.com/mountyrox                                 *
+#*                                                                          *
+#*                                                                          *
+#* All trademarks within this guide belong to their legitimate owners.      *
+#*                                                                          *
+#*   This program is free software; you can redistribute it and/or modify   *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)     *
+#*   as published by the Free Software Foundation; either version 2 of      *
+#*   the License, or (at your option) any later version.                    *
+#*   for detail see the LICENCE text file.                                  *
+#*                                                                          *
+#*   This program is distributed in the hope that it will be useful,        *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+#*   GNU Library General Public License for more details.                   *
+#*                                                                          *
+#*   You should have received a copy of the GNU Library General Public      *
+#*   License along with this program; if not, write to the Free Software    *
+#*   Foundation, Inc.,                                                      *
+#*   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA           *
+#*                                                                          *
+#****************************************************************************
+
+
+
+
+# This is derived from a cadquery script for generating PDIP models in X3D format
+#
+# from https://bitbucket.org/hyOzd/freecad-macros
+# author hyOzd
+
+
+# Dimensions are from data sheets given in the settings of the corresponding KiCad footprint:
+
+## requirements
+## cadquery FreeCAD plugin
+##   https://github.com/jmwright/cadquery-freecad-module
+
+## to run the script just do: freecad main_generator.py modelName
+## e.g. c:\freecad\bin\freecad main_generator.py all
+
+## the script will generate STEP and VRML parametric models
+## to be used with kicad StepUp script
+
+#* These are a FreeCAD & cadquery tools                                     *
+#* to export generated models in STEP & VRML format.                        *
+#*                                                                          *
+#* cadquery script for generating QFP/SOIC/SSOP/TSSOP models in STEP AP214  *
+#*   Copyright (c) 2015                                                     *
+#* Maurice https://launchpad.net/~easyw                                     *
+#* All trademarks within this guide belong to their legitimate owners.      *
+#*                                                                          *
+#*   This program is free software; you can redistribute it and/or modify   *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)     *
+#*   as published by the Free Software Foundation; either version 2 of      *
+#*   the License, or (at your option) any later version.                    *
+#*   for detail see the LICENCE text file.                                  *
+#*                                                                          *
+#*   This program is distributed in the hope that it will be useful,        *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+#*   GNU Library General Public License for more details.                   *
+#*                                                                          *
+#*   You should have received a copy of the GNU Library General Public      *
+#*   License along with this program; if not, write to the Free Software    *
+#*   Foundation, Inc.,                                                      *
+#*   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA           *
+#*                                                                          *
+#****************************************************************************
+
+__title__ = "make Tact switch 3D models"
+__author__ = "MountyRox, based on DIP_parts and Buzzer_Beeper scripts"
+__Comment__ = 'make tactile switches 3D models exported to STEP and VRML for Kicad StepUP script'
+
+___ver___ = "1.0.0 21/10/2020"
+
+import collections
+from collections import namedtuple
+
+import math
+import sys, os
+import datetime
+from datetime import datetime
+import re, fnmatch
+
+outdir=os.path.dirname(os.path.realpath(__file__)+"/../_3Dmodels")
+script_dir  = os.path.dirname(os.path.realpath(__file__))
+scripts_root = script_dir.split(script_dir.split(os.sep)[-1])[0]
+
+print (script_dir)
+sys.path.append(script_dir)
+sys.path.append(scripts_root + "_tools")
+
+import exportPartToVRML as expVRML
+import shaderColors
+
+
+# maui start
+import FreeCAD, Draft, FreeCADGui
+import ImportGui
+import FreeCADGui as Gui
+#from Gui.Command import *
+
+
+if FreeCAD.GuiUp:
+    from PySide import QtCore, QtGui
+
+# Licence information of the generated models.
+#################################################################################################
+STR_licAuthor = "kicad StepUp"
+STR_licEmail = "ksu"
+STR_licOrgSys = "kicad StepUp"
+STR_licPreProc = "OCC"
+STR_licOrg = "FreeCAD"
+
+
+#################################################################################################
+
+def reload_lib(lib):
+    if (sys.version_info > (3, 0)):
+        import importlib
+        importlib.reload(lib)
+    else:
+        reload (lib)
+
+
+
+import cq_parameters 
+reload_lib(cq_parameters)
+
+import cq_base_model  
+reload_lib(cq_base_model)
+
+# models for Omron, Panasonic, C&K, Alps tactile switches
+import cq_base_tact_switches 
+from cq_base_tact_switches import cqMakerTactSwitch, TactSwitchSeries, partsTactSwitches
+reload_lib(cq_base_tact_switches)
+
+# models for C&K PTS125 and Wuerth  tactile switches
+import cq_cuk_pts125sx  
+from cq_cuk_pts125sx import parts_cuk_pts125s, cqMakerCuKPTS125SxTactSwitch
+reload_lib(cq_cuk_pts125sx)
+
+# models for side actuated switches from Omron, Panasonic
+import cq_ultra_small_tact_switch  
+from cq_ultra_small_tact_switch import *
+reload_lib(cq_ultra_small_tact_switch)
+
+# models for C&K KMR2 tactile switches
+import cq_cuk_kmr2x  
+from cq_cuk_kmr2x import *
+reload_lib(cq_cuk_kmr2x)
+
+# models for C&K PTS810 tactile switches
+import cq_cuk_pts810x  
+from cq_cuk_pts810x import *
+reload_lib(cq_cuk_pts810x)
+
+
+def clear_console():
+    #clearing previous messages
+    mw=FreeCADGui.getMainWindow()
+    c=mw.findChild(QtGui.QPlainTextEdit, "Python console")
+    c.clear()
+    r=mw.findChild(QtGui.QTextEdit, "Report view")
+    r.clear()
+
+clear_console()
+
+
+# Array of model classes
+different_models = [
+    partsTactSwitches(),
+    parts_cuk_pts125s(),
+    partsUltraSmallTactSwitches(),
+    parts_cuk_kmr2(),
+    parts_cuk_pts810(),
+    ]
+
+
+def make_3D_model(models_dir, model_class, modelName):
+    r"""Creates a 3D model and exports it to STEO and VRML.
+    :param models_dir: directory name for STEP and VRML 3D model file export
+    :type  models_dir: ``string``
+    :param model_class: Class containing functions and parameter to generate the 3D model
+    :type  model_class: ``class``
+    :param modelName: The KiCad file name of the 3D model. 
+    :type  modelName: ``string``
+
+    """
+    if not model_class.isValidModel ():
+        FreeCAD.Console.PrintMessage("Model: " + modelName + ' has invalid parameter and was skipped.\r\n')
+        return
+
+    LIST_license = ["",]
+
+    CheckedmodelName = modelName.replace('.', '').replace('-', '_').replace('(', '').replace(')', '')
+    Newdoc = App.newDocument(CheckedmodelName)
+    App.setActiveDocument(CheckedmodelName)
+    Gui.ActiveDocument=Gui.getDocument(CheckedmodelName)
+    destination_dir = model_class.get_dest_3D_dir()
+    
+    material_substitutions = model_class.make_3D_model()
+    
+    doc = FreeCAD.ActiveDocument
+    doc.Label = CheckedmodelName
+
+    objs=GetListOfObjects(FreeCAD, doc)
+    objs[0].Label = CheckedmodelName
+    restore_Main_Tools()
+
+    script_dir=os.path.dirname(os.path.realpath(__file__))
+    expVRML.say(models_dir)
+    out_dir=models_dir+os.sep+destination_dir
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    exportSTEP(doc, modelName, out_dir)
+    if LIST_license[0]=="":
+        LIST_license=Lic.LIST_int_license
+        LIST_license.append("")
+    Lic.addLicenseToStep(out_dir+'/', modelName+".step", LIST_license,\
+                       STR_licAuthor, STR_licEmail, STR_licOrgSys, STR_licOrg, STR_licPreProc)
+
+    # scale and export Vrml model
+    scale=1/2.54
+    #exportVRML(doc,modelName,scale,out_dir)
+    del objs
+    objs=GetListOfObjects(FreeCAD, doc)
+    expVRML.say("######################################################################")
+    expVRML.say(objs)
+    expVRML.say("######################################################################")
+    export_objects, used_color_keys = expVRML.determineColors(Gui, objs, material_substitutions)
+    export_file_name=out_dir + os.sep + modelName + '.wrl'
+    colored_meshes = expVRML.getColoredMesh(Gui, export_objects , scale)
+    #expVRML.writeVRMLFile(colored_meshes, export_file_name, used_color_keys)# , LIST_license
+    expVRML.writeVRMLFile(colored_meshes, export_file_name, used_color_keys, LIST_license)
+    #scale=0.3937001
+    #exportVRML(doc,modelName,scale,out_dir)
+    # Save the doc in Native FC format
+    saveFCdoc(App, Gui, doc, modelName,out_dir)
+    #display BBox
+    Gui.activateWorkbench("PartWorkbench")
+    Gui.SendMsgToActiveView("ViewFit")
+    Gui.activeDocument().activeView().viewAxometric()
+    #FreeCADGui.ActiveDocument.activeObject.BoundingBox = True
+
+
+
+#import step_license as L
+import add_license as Lic
+
+# when run from command line
+if __name__ == "__main__" or __name__ == "main_generator":
+
+    FreeCAD.Console.PrintMessage('\r\nRunning...\r\n')
+
+    full_path=os.path.realpath(__file__)
+    expVRML.say(full_path)
+    scriptdir=os.path.dirname(os.path.realpath(__file__))
+    expVRML.say(scriptdir)
+    sub_path = full_path.split(scriptdir)
+    expVRML.say(sub_path)
+    sub_dir_name =full_path.split(os.sep)[-2]
+    expVRML.say(sub_dir_name)
+    sub_path = full_path.split(sub_dir_name)[0]
+    expVRML.say(sub_path)
+    models_dir=sub_path+"_3Dmodels"
+    
+    model_to_build = ''
+    if len(sys.argv) < 3:
+        FreeCAD.Console.PrintMessage('\
+            No variant name is given, add a valid model name as an argument.\r\n\r\n\
+            Valid arguments are:\r\n\
+           \t"all"\t\t generate all models\r\n\
+           \t"list"\t\t lists all models\r\n\r\n\
+           or any search pattern like:\r\n\
+           \t"*b3fs*"\t\t to generate all models containing B3SF\r\n')
+        #model_to_build =  '*b3fs-105*'#
+    else:
+        model_to_build=sys.argv[2]
+
+    found_one = False
+    listOnly = model_to_build == 'list'
+
+    if len(model_to_build) > 0:
+        qfilter = '*' if model_to_build == "all" or model_to_build == "list" else model_to_build
+        qfilter = re.compile(fnmatch.translate(qfilter), re.IGNORECASE)
+        for modelType in different_models:
+            paramList = modelType.get_param_list_all()  # get param list of all variants 
+            for iParam in paramList:
+                if listOnly:
+                    FreeCAD.Console.PrintMessage('Model :' + iParam + '\r\n')
+                else:
+                    if qfilter.match(iParam):
+                        found_one = True
+                        #listModelsToBuild.append(modelType.getModelVariant (iParam))
+                        # make an instance of the current model and initialize it with the corresponding parameter set
+                        model = modelType.getModelVariant (iParam)
+                        make_3D_model (models_dir, model, iParam)
+                        #model.make_3D_model ()
+
+        if not found_one and not listOnly:
+            FreeCAD.Console.PrintMessage("\r\n========  Parameters for %s doesn't exist, skipping. ==========\r\n " % model_to_build)


### PR DESCRIPTION
Following files will be added:

 On branch mr_Button_Switch_Tactile_SMD_THT
 Changes to be committed:
	new file:   cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/README.md
	new file:   cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_base_model.py
	new file:   cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_base_tact_switches.py
	new file:   cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_cuk_kmr2x.py
	new file:   cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_cuk_pts125sx.py
	new file:   cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_cuk_pts810x.py
	new file:   cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_parameters.py
	new file:   cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/cq_ultra_small_tact_switch.py
	new file:   cadquery/FCAD_script_generator/Button_Switch_Tactile_SMD_THT/main_generator.py

The scripts are based on files from _DIP_parts_  and _Buzzer_Beeper_.
A list of 3D models (SMD and THT) which can be generated is given in the _ReadMe_ file.
For the new generated 3D models i will launch a PR on [https://gitlab.com/kicad/libraries/kicad-packages3D](url)   
    
Here are some examples:
![SW_TH_Tactile_Omron_B3F-10xx](https://user-images.githubusercontent.com/68644672/97731942-11452600-1ad6-11eb-934b-7bf1a6c1a3e9.png)  Omron B3F
![SW_SPST_B3U-3000P](https://user-images.githubusercontent.com/68644672/97732082-4a7d9600-1ad6-11eb-9fdd-33905bc18e2f.png)  Omron B3U-3000P
![SW_SPST_Panasonic_EVQPL_3PL_5PL_PT_A15](https://user-images.githubusercontent.com/68644672/97732234-87498d00-1ad6-11eb-9268-e5d7c5decb37.png)  Panasonic EVQPL


