### PR TITLE
Taller CP_Radial_THT

### DIFF
--- a/cadquery/FCAD_script_generator/Box_Headers/main_generator.py
+++ b/cadquery/FCAD_script_generator/Box_Headers/main_generator.py
@@ -62,6 +62,8 @@ LIST_license = ["",]
 
 save_memory = True #reducing memory consuming for all generation params
 check_Model = True
+save_memory = False #reducing memory consuming for all generation params
+check_Model = False
 check_log_file = 'check-log.md'
 
 body_color_key = "black body"
@@ -332,14 +334,16 @@ def MakeHeader(n, isAngled, isSMT, log, highDetail=False):
     base = MakeBase(n, highDetail)
 
     if (isAngled):
+        #pins = MakeAnglePinRow(n, -3, 5.94, 12.38, highDetail)
         pins = MakeAnglePinRow(n, -3, 5.94, 12.38, highDetail)
-        pins = pins.union(MakeAnglePinRow(n, -3, 3.40, 9.84, highDetail).translate((2.54,0,0)))
+        #pins = pins.union(MakeAnglePinRow(n, -3, 3.40, 9.84, highDetail).translate((2.54,0,0)))
         #                                 n,  Z,    H,    L
-
+        pins = pins.union(MakeAnglePinRow(n, -3, 3.40, 9.84, highDetail).translate((2.54,0,0)))
         # rotate the base into the angled position
         base = base.rotate((0,0,0),(0,1,0),90).translate((4.13,0,5.94))
+        #pins = pins.rotate((0,0,0),(0,1,0),270)
     elif (isSMT):
-	#pad length: (9.5mm/2) - 1.27mm = 3.48mm
+	#pad length: (9.5mm/2) - 1.27mm = 
         pins = MakeSMTPinRow(n, -3, 9.5, 3.48, 0, highDetail)
         pins = pins.union(MakeSMTPinRow(n, -3, 9.5, 3.48, 180, highDetail).translate((2.54,0,0)))
         base = base.translate((0,0,1.5))
@@ -411,6 +415,7 @@ def MakeHeader(n, isAngled, isSMT, log, highDetail=False):
     if check_Model==True:
         runGeometryCheck(App, Gui, step_path,
             log, name, save_memory=save_memory)
+
 
 if __name__ == "__main__" or __name__ == "main_generator":
     pins = []

--- a/cadquery/FCAD_script_generator/Box_Headers/main_generator.py
+++ b/cadquery/FCAD_script_generator/Box_Headers/main_generator.py
@@ -62,8 +62,6 @@ LIST_license = ["",]
 
 save_memory = True #reducing memory consuming for all generation params
 check_Model = True
-save_memory = False #reducing memory consuming for all generation params
-check_Model = False
 check_log_file = 'check-log.md'
 
 body_color_key = "black body"
@@ -208,37 +206,6 @@ def MakePin(Z, H):
 
     return pin
 
-# make a single SMT pin
-def MakeSMTPin(Z, H, L, Rotation=0, highDetail=False):
-    #H = pin height (above board)
-    #L = length of solder part flat on board
-    #Rotation is vertical rotation of pin, 0 or 180°
-
-    #pin size
-    size = 0.64
-    #no underboard stuff
-    Z=0
-
-    pin = cq.Workplane("XY").workplane(offset=Z).rect(size,size).extrude(H - Z)
-
-    pin = pin.union(cq.Workplane("YZ").workplane(offset=-(size/2.0)).rect(size,size).extrude(-(L-size/2.0)).translate((0,0,size/2.0)))
-
-    #Chamfer C
-    C = 0.2
-    #top
-    pin = pin.faces(">Z").chamfer(C)
-    #left
-    pin = pin.faces("<X").chamfer(C)
-
-    # fillet on back of pin
-    if (highDetail):
-        R = size
-        pin = pin.faces("<Z").edges(">X").fillet(R)
-
-    pin = pin.rotate((0,0,0),(0,0,1),Rotation)
-
-    return pin
-
 # make a single angle pin
 def MakeAnglePin(Z, H, L, highDetail=False):
     #pin size
@@ -268,16 +235,6 @@ def MakePinRow(n, Z, H):
 
     return pin
 
-# make a row of SMT (bent) pins
-def MakeSMTPinRow(n, Z, H, L, Rotation=0, highDetail=False):
-
-    pin = MakeSMTPin(Z, H, L, Rotation, highDetail)
-
-    for i in range(1,n):
-        pin = pin.union(MakeSMTPin(Z, H, L, Rotation, highDetail).translate((0,-2.54 * i,0)))
-
-    return pin
-
 # make a row of angled (bent) pins
 def MakeAnglePinRow(n, Z, H, L, highDetail=False):
 
@@ -289,17 +246,15 @@ def MakeAnglePinRow(n, Z, H, L, highDetail=False):
     return pin
 
 # generate a name for the pin header
-def HeaderName(n, isAngled, isSMT):
+def HeaderName(n, isAngled):
     if (isAngled):
         return "IDC-Header_2x{n:02}_P2.54mm_Horizontal".format(n=n)
-    elif (isSMT):
-        return "IDC-Header_2x{n:02}_P2.54mm_Vertical_SMT".format(n=n)
     else:
         return "IDC-Header_2x{n:02}_P2.54mm_Vertical".format(n=n)
 
 # make a pin header using supplied parameters, n pins in each row
 
-def MakeHeader(n, isAngled, isSMT, log, highDetail=False):
+def MakeHeader(n, isAngled, log, highDetail=False):
     global LIST_license
     if LIST_license[0]=="":
         LIST_license=Lic.LIST_int_license
@@ -307,7 +262,7 @@ def MakeHeader(n, isAngled, isSMT, log, highDetail=False):
 
     LIST_license[0] = "Copyright (C) "+datetime.now().strftime("%Y")+", " + STR_licAuthor
 
-    name = HeaderName(n, isAngled, isSMT)
+    name = HeaderName(n, isAngled)
     print('\n############ ' + name + ' #############\n')
 
     lib_name='Connector_IDC'
@@ -334,19 +289,10 @@ def MakeHeader(n, isAngled, isSMT, log, highDetail=False):
     base = MakeBase(n, highDetail)
 
     if (isAngled):
-        #pins = MakeAnglePinRow(n, -3, 5.94, 12.38, highDetail)
         pins = MakeAnglePinRow(n, -3, 5.94, 12.38, highDetail)
-        #pins = pins.union(MakeAnglePinRow(n, -3, 3.40, 9.84, highDetail).translate((2.54,0,0)))
-        #                                 n,  Z,    H,    L
         pins = pins.union(MakeAnglePinRow(n, -3, 3.40, 9.84, highDetail).translate((2.54,0,0)))
         # rotate the base into the angled position
         base = base.rotate((0,0,0),(0,1,0),90).translate((4.13,0,5.94))
-        #pins = pins.rotate((0,0,0),(0,1,0),270)
-    elif (isSMT):
-	#pad length: (9.5mm/2) - 1.27mm = 
-        pins = MakeSMTPinRow(n, -3, 9.5, 3.48, 0, highDetail)
-        pins = pins.union(MakeSMTPinRow(n, -3, 9.5, 3.48, 180, highDetail).translate((2.54,0,0)))
-        base = base.translate((0,0,1.5))
     else:
         pins = MakePinRow(n, -3.0, 8.0)
         pins = pins.union(MakePinRow(n, -3.0, 8.0).translate((2.54,0,0)))
@@ -416,7 +362,6 @@ def MakeHeader(n, isAngled, isSMT, log, highDetail=False):
         runGeometryCheck(App, Gui, step_path,
             log, name, save_memory=save_memory)
 
-
 if __name__ == "__main__" or __name__ == "main_generator":
     pins = []
     # select whether to include visual detail features
@@ -439,13 +384,7 @@ if __name__ == "__main__" or __name__ == "main_generator":
         for pin in pins:
             # make an angled and a straight version
             for isAngled in (True, False):
-                if isAngled == False:
-                    # SMT or not
-                    for isSMT in (True, False):
-                        out_dir = MakeHeader(pin, isAngled, isSMT, log, highDetail)
-                else:
-                    # No SMT for Horizontal (yet)
-                    out_dir = MakeHeader(pin, isAngled, False, log, highDetail)
+                out_dir = MakeHeader(pin, isAngled, log, highDetail)
 
 
 # when run from freecad-cadquery

--- a/cadquery/FCAD_script_generator/Box_Headers/main_generator.py
+++ b/cadquery/FCAD_script_generator/Box_Headers/main_generator.py
@@ -62,8 +62,6 @@ LIST_license = ["",]
 
 save_memory = True #reducing memory consuming for all generation params
 check_Model = True
-save_memory = False #reducing memory consuming for all generation params
-check_Model = False
 check_log_file = 'check-log.md'
 
 body_color_key = "black body"
@@ -334,16 +332,14 @@ def MakeHeader(n, isAngled, isSMT, log, highDetail=False):
     base = MakeBase(n, highDetail)
 
     if (isAngled):
-        #pins = MakeAnglePinRow(n, -3, 5.94, 12.38, highDetail)
         pins = MakeAnglePinRow(n, -3, 5.94, 12.38, highDetail)
-        #pins = pins.union(MakeAnglePinRow(n, -3, 3.40, 9.84, highDetail).translate((2.54,0,0)))
-        #                                 n,  Z,    H,    L
         pins = pins.union(MakeAnglePinRow(n, -3, 3.40, 9.84, highDetail).translate((2.54,0,0)))
+        #                                 n,  Z,    H,    L
+
         # rotate the base into the angled position
         base = base.rotate((0,0,0),(0,1,0),90).translate((4.13,0,5.94))
-        #pins = pins.rotate((0,0,0),(0,1,0),270)
     elif (isSMT):
-	#pad length: (9.5mm/2) - 1.27mm = 
+	#pad length: (9.5mm/2) - 1.27mm = 3.48mm
         pins = MakeSMTPinRow(n, -3, 9.5, 3.48, 0, highDetail)
         pins = pins.union(MakeSMTPinRow(n, -3, 9.5, 3.48, 180, highDetail).translate((2.54,0,0)))
         base = base.translate((0,0,1.5))
@@ -415,7 +411,6 @@ def MakeHeader(n, isAngled, isSMT, log, highDetail=False):
     if check_Model==True:
         runGeometryCheck(App, Gui, step_path,
             log, name, save_memory=save_memory)
-
 
 if __name__ == "__main__" or __name__ == "main_generator":
     pins = []

--- a/cadquery/FCAD_script_generator/CP_Radial_THT/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/CP_Radial_THT/cq_parameters.py
@@ -711,7 +711,7 @@ kicad_naming_params_radial_th_cap = {
         rotation  = 180, # rotation if required
         dest_dir_prefix = '../Capacitors_THT.3dshapes/'
     ),
-    "CP_Radial_D10.0mm_L12.5mm_P5.0mm" : Params(# Nichicon UVZ 10x12.5 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
+    "CP_Radial_D10.0mm_L12.5mm_P5.00mm" : Params(# Nichicon UVZ 10x12.5 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
         L = 12.5,
         D = 10.,
         d = 0.6,
@@ -722,11 +722,11 @@ kicad_naming_params_radial_th_cap = {
         pol = True,
         pin3 = None,
         xoffset = None, 
-        modelName = 'CP_Radial_D10.0mm_L12.5mm_P5.0mm', #modelName
+        modelName = 'CP_Radial_D10.0mm_L12.5mm_P5.00mm', #modelName
         rotation  = 180, # rotation if required
         dest_dir_prefix = '../Capacitors_THT.3dshapes/'
     ),
-    "CP_Radial_D10.0mm_L16.0mm_P5.0mm" : Params(# Nichicon UVZ 10x16 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
+    "CP_Radial_D10.0mm_L16.0mm_P5.00mm" : Params(# Nichicon UVZ 10x16 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
         L = 16.,
         D = 10.,
         d = 0.6,
@@ -737,11 +737,11 @@ kicad_naming_params_radial_th_cap = {
         pol = True,
         pin3 = None,
         xoffset = None, 
-        modelName = 'CP_Radial_D10.0mm_L16.0mm_P5.0mm', #modelName
+        modelName = 'CP_Radial_D10.0mm_L16.0mm_P5.00mm', #modelName
         rotation  = 180, # rotation if required
         dest_dir_prefix = '../Capacitors_THT.3dshapes/'
     ),
-    "CP_Radial_D10.0mm_L20.0mm_P5.0mm" : Params(# Nichicon UVZ 10x20 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
+    "CP_Radial_D10.0mm_L20.0mm_P5.00mm" : Params(# Nichicon UVZ 10x20 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
         L = 20.,
         D = 10.,
         d = 0.6,
@@ -752,7 +752,7 @@ kicad_naming_params_radial_th_cap = {
         pol = True,
         pin3 = None,
         xoffset = None, 
-        modelName = 'CP_Radial_D10.0mm_L20.0mm_P5.0mm', #modelName
+        modelName = 'CP_Radial_D10.0mm_L20.0mm_P5.00mm', #modelName
         rotation  = 180, # rotation if required
         dest_dir_prefix = '../Capacitors_THT.3dshapes/'
     ),
@@ -816,7 +816,7 @@ kicad_naming_params_radial_th_cap = {
         rotation  = 180, # rotation if required
         dest_dir_prefix = '../Capacitors_THT.3dshapes/'
     ),
-    "CP_Radial_D12.5mm_L20.0mm_P5.0mm" : Params(# Nichicon UVZ 12.5x20 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
+    "CP_Radial_D12.5mm_L20.0mm_P5.00mm" : Params(# Nichicon UVZ 12.5x20 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
         L = 20.,
         D = 12.5,
         d = 0.6,
@@ -827,11 +827,11 @@ kicad_naming_params_radial_th_cap = {
         pol = True,
         pin3 = None,
         xoffset = None, 
-        modelName = 'CP_Radial_D12.5mm_L20.0mm_P5.0mm', #modelName
+        modelName = 'CP_Radial_D12.5mm_L20.0mm_P5.00mm', #modelName
         rotation  = 180, # rotation if required
         dest_dir_prefix = '../Capacitors_THT.3dshapes/'
     ),
-    "CP_Radial_D12.5mm_L25.0mm_P5.0mm" : Params(# Nichicon UVZ 12.5x20 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
+    "CP_Radial_D12.5mm_L25.0mm_P5.00mm" : Params(# Nichicon UVZ 12.5x25 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
         L = 25.,
         D = 12.5,
         d = 0.6,
@@ -842,7 +842,7 @@ kicad_naming_params_radial_th_cap = {
         pol = True,
         pin3 = None,
         xoffset = None, 
-        modelName = 'CP_Radial_D12.5mm_L25.0mm_P5.0mm', #modelName
+        modelName = 'CP_Radial_D12.5mm_L25.0mm_P5.00mm', #modelName
         rotation  = 180, # rotation if required
         dest_dir_prefix = '../Capacitors_THT.3dshapes/'
     ),
@@ -948,6 +948,36 @@ kicad_naming_params_radial_th_cap = {
         pin3 = None,
         xoffset = None, 
         modelName = 'CP_Radial_D16.0mm_P7.50mm', #modelName
+        rotation  = 180, # rotation if required
+        dest_dir_prefix = '../Capacitors_THT.3dshapes/'
+    ),
+    "CP_Radial_D16.0mm_L25.0mm_P7.50mm" : Params(# Nichicon UVZ 16x25 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
+        L = 25.,
+        D = 16.,
+        d = 0.8,
+        F = 7.5,
+        ll = 2.0,
+        la = 0.0,
+        bs = 0.,
+        pol = True,
+        pin3 = None,
+        xoffset = None, 
+        modelName = 'CP_Radial_D16.0mm_L25.0mm_P7.50mm', #modelName
+        rotation  = 180, # rotation if required
+        dest_dir_prefix = '../Capacitors_THT.3dshapes/'
+    ),
+    "CP_Radial_D16.0mm_L35.5mm_P7.50mm" : Params(# Nichicon UVZ 16x35.5 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
+        L = 35.5,
+        D = 16.,
+        d = 0.8,
+        F = 7.5,
+        ll = 2.0,
+        la = 0.0,
+        bs = 0.,
+        pol = True,
+        pin3 = None,
+        xoffset = None, 
+        modelName = 'CP_Radial_D16.0mm_L35.5mm_P7.50mm', #modelName
         rotation  = 180, # rotation if required
         dest_dir_prefix = '../Capacitors_THT.3dshapes/'
     ),

--- a/cadquery/FCAD_script_generator/CP_Radial_THT/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/CP_Radial_THT/cq_parameters.py
@@ -531,7 +531,7 @@ kicad_naming_params_radial_th_cap = {
         rotation  = 180, # rotation if required
         dest_dir_prefix = '../Capacitors_THT.3dshapes/'
     ),
-    "CP_Radial_D6.3mm_L11.0mm_P2.50mm" : Params(# Nichicon UVZ 5x11 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
+    "CP_Radial_D6.3mm_L11.0mm_P2.50mm" : Params(# Nichicon UVZ 6.3x11 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
         L = 11.,
         D = 6.3,
         d = 0.5,
@@ -588,6 +588,21 @@ kicad_naming_params_radial_th_cap = {
         pin3 = None,
         xoffset = None, 
         modelName = 'CP_Radial_D8.0mm_P3.50mm', #modelName
+        rotation  = 180, # rotation if required
+        dest_dir_prefix = '../Capacitors_THT.3dshapes/'
+    ),
+    "CP_Radial_D8.0mm_L11.5mm_P3.50mm" : Params(# Nichicon UVZ 8x11.5 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
+        L = 11.5,
+        D = 8.,
+        d = 0.6,
+        F = 3.5,
+        ll = 2.0,
+        la = 0.0,
+        bs = 0.,
+        pol = True,
+        pin3 = None,
+        xoffset = None, 
+        modelName = 'CP_Radial_D8.0mm_L11.5mm_P3.50mm', #modelName
         rotation  = 180, # rotation if required
         dest_dir_prefix = '../Capacitors_THT.3dshapes/'
     ),
@@ -693,6 +708,51 @@ kicad_naming_params_radial_th_cap = {
         pin3 = None,
         xoffset = None, 
         modelName = 'CP_Radial_D10.0mm_P5.00mm', #modelName
+        rotation  = 180, # rotation if required
+        dest_dir_prefix = '../Capacitors_THT.3dshapes/'
+    ),
+    "CP_Radial_D10.0mm_L12.5mm_P5.0mm" : Params(# Nichicon UVZ 10x12.5 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
+        L = 12.5,
+        D = 10.,
+        d = 0.6,
+        F = 5.,
+        ll = 2.0,
+        la = 0.0,
+        bs = 0.,
+        pol = True,
+        pin3 = None,
+        xoffset = None, 
+        modelName = 'CP_Radial_D10.0mm_L12.5mm_P5.0mm', #modelName
+        rotation  = 180, # rotation if required
+        dest_dir_prefix = '../Capacitors_THT.3dshapes/'
+    ),
+    "CP_Radial_D10.0mm_L16.0mm_P5.0mm" : Params(# Nichicon UVZ 10x16 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
+        L = 16.,
+        D = 10.,
+        d = 0.6,
+        F = 5.,
+        ll = 2.0,
+        la = 0.0,
+        bs = 0.,
+        pol = True,
+        pin3 = None,
+        xoffset = None, 
+        modelName = 'CP_Radial_D10.0mm_L16.0mm_P5.0mm', #modelName
+        rotation  = 180, # rotation if required
+        dest_dir_prefix = '../Capacitors_THT.3dshapes/'
+    ),
+    "CP_Radial_D10.0mm_L20.0mm_P5.0mm" : Params(# Nichicon UVZ 10x20 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
+        L = 20.,
+        D = 10.,
+        d = 0.6,
+        F = 5.,
+        ll = 2.0,
+        la = 0.0,
+        bs = 0.,
+        pol = True,
+        pin3 = None,
+        xoffset = None, 
+        modelName = 'CP_Radial_D10.0mm_L20.0mm_P5.0mm', #modelName
         rotation  = 180, # rotation if required
         dest_dir_prefix = '../Capacitors_THT.3dshapes/'
     ),

--- a/cadquery/FCAD_script_generator/CP_Radial_THT/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/CP_Radial_THT/cq_parameters.py
@@ -1011,6 +1011,21 @@ kicad_naming_params_radial_th_cap = {
         rotation  = 180, # rotation if required
         dest_dir_prefix = '../Capacitors_THT.3dshapes/'
     ),
+    "CP_Radial_D18.0mm_L35.5mm_P7.50mm" : Params(# Nichicon UVZ 18x35.5 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
+        L = 35.5,
+        D = 18.,
+        d = 0.8,
+        F = 7.5,
+        ll = 2.0,
+        la = 0.0,
+        bs = 0.,
+        pol = True,
+        pin3 = None,
+        xoffset = None, 
+        modelName = 'CP_Radial_D18.0mm_L35.5mm_P7.50mm', #modelName
+        rotation  = 180, # rotation if required
+        dest_dir_prefix = '../Capacitors_THT.3dshapes/'
+    ),
     "CP_Radial_D22.0mm_P10.00mm_3pin_SnapIn" : Params(# from Jan Kriege's 3d models
         L = 22.0,
         D = 22.0,

--- a/cadquery/FCAD_script_generator/CP_Radial_THT/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/CP_Radial_THT/cq_parameters.py
@@ -816,6 +816,36 @@ kicad_naming_params_radial_th_cap = {
         rotation  = 180, # rotation if required
         dest_dir_prefix = '../Capacitors_THT.3dshapes/'
     ),
+    "CP_Radial_D12.5mm_L20.0mm_P5.0mm" : Params(# Nichicon UVZ 12.5x20 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
+        L = 20.,
+        D = 12.5,
+        d = 0.6,
+        F = 5.,
+        ll = 2.0,
+        la = 0.0,
+        bs = 0.,
+        pol = True,
+        pin3 = None,
+        xoffset = None, 
+        modelName = 'CP_Radial_D12.5mm_L20.0mm_P5.0mm', #modelName
+        rotation  = 180, # rotation if required
+        dest_dir_prefix = '../Capacitors_THT.3dshapes/'
+    ),
+    "CP_Radial_D12.5mm_L25.0mm_P5.0mm" : Params(# Nichicon UVZ 12.5x20 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
+        L = 25.,
+        D = 12.5,
+        d = 0.6,
+        F = 5.,
+        ll = 2.0,
+        la = 0.0,
+        bs = 0.,
+        pol = True,
+        pin3 = None,
+        xoffset = None, 
+        modelName = 'CP_Radial_D12.5mm_L25.0mm_P5.0mm', #modelName
+        rotation  = 180, # rotation if required
+        dest_dir_prefix = '../Capacitors_THT.3dshapes/'
+    ),
     "CP_Radial_D12.5mm_P7.50mm" : Params(# from Jan Kriege's 3d models
         L = 12.5,
         D = 12.5,

--- a/cadquery/FCAD_script_generator/CP_Radial_THT/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/CP_Radial_THT/cq_parameters.py
@@ -486,6 +486,21 @@ kicad_naming_params_radial_th_cap = {
         rotation  = 180, # rotation if required
         dest_dir_prefix = '../Capacitors_THT.3dshapes/'
     ),
+    "CP_Radial_D5.0mm_L11.0mm_P2.00mm" : Params(# Nichicon UVZ 5x11 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
+        L = 11.,
+        D = 5.,
+        d = 0.5,
+        F = 2.0,
+        ll = 2.0,
+        la = 0.0,
+        bs = 0.,
+        pol = True,
+        pin3 = None,
+        xoffset = None, 
+        modelName = 'CP_Radial_D5.0mm_L11.0mm_P2.00mm', #modelName
+        rotation  = 180, # rotation if required
+        dest_dir_prefix = '../Capacitors_THT.3dshapes/'
+    ),
     "CP_Radial_D5.0mm_P2.50mm" : Params(# from Jan Kriege's 3d models
         L = 5,
         D = 5.,
@@ -513,6 +528,21 @@ kicad_naming_params_radial_th_cap = {
         pin3 = None,
         xoffset = None, 
         modelName = 'CP_Radial_D6.3mm_P2.50mm', #modelName
+        rotation  = 180, # rotation if required
+        dest_dir_prefix = '../Capacitors_THT.3dshapes/'
+    ),
+    "CP_Radial_D6.3mm_L11.0mm_P2.50mm" : Params(# Nichicon UVZ 5x11 https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf
+        L = 11.,
+        D = 6.3,
+        d = 0.5,
+        F = 2.5,
+        ll = 2.0,
+        la = 0.0,
+        bs = 0.,
+        pol = True,
+        pin3 = None,
+        xoffset = None, 
+        modelName = 'CP_Radial_D6.3mm_L11.0mm_P2.50mm', #modelName
         rotation  = 180, # rotation if required
         dest_dir_prefix = '../Capacitors_THT.3dshapes/'
     ),

--- a/cadquery/FCAD_script_generator/CP_Radial_THT/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/CP_Radial_THT/cq_parameters.py
@@ -591,21 +591,6 @@ kicad_naming_params_radial_th_cap = {
         rotation  = 180, # rotation if required
         dest_dir_prefix = '../Capacitors_THT.3dshapes/'
     ),
-    "CP_Radial_D8.0mm_P3.50mm" : Params(# from Jan Kriege's 3d models
-        L = 8.0,
-        D = 8.0,
-        d = 0.5,
-        F = 3.5,
-        ll = 2.0,
-        la = 0.0,
-        bs = 0.,
-        pol = True,
-        pin3 = None,
-        xoffset = None, 
-        modelName = 'CP_Radial_D8.0mm_P3.50mm', #modelName
-        rotation  = 180, # rotation if required
-        dest_dir_prefix = '../Capacitors_THT.3dshapes/'
-    ),
     "CP_Radial_D8.0mm_P3.80mm" : Params(# from Jan Kriege's 3d models
         L = 8.0,
         D = 8.0,

--- a/cadquery/FCAD_script_generator/CP_Radial_THT/cq_parameters.py
+++ b/cadquery/FCAD_script_generator/CP_Radial_THT/cq_parameters.py
@@ -1011,21 +1011,6 @@ kicad_naming_params_radial_th_cap = {
         rotation  = 180, # rotation if required
         dest_dir_prefix = '../Capacitors_THT.3dshapes/'
     ),
-    "CP_Radial_D18.0mm_P7.50mm" : Params(# from Jan Kriege's 3d models
-        L = 18.0,
-        D = 18.0,
-        d = 0.9,
-        F = 7.5,
-        ll = 2.0,
-        la = 0.0,
-        bs = 0.,
-        pol = True,
-        pin3 = None,
-        xoffset = None, 
-        modelName = 'CP_Radial_D18.0mm_P7.50mm', #modelName
-        rotation  = 180, # rotation if required
-        dest_dir_prefix = '../Capacitors_THT.3dshapes/'
-    ),
     "CP_Radial_D22.0mm_P10.00mm_3pin_SnapIn" : Params(# from Jan Kriege's 3d models
         L = 22.0,
         D = 22.0,


### PR DESCRIPTION
This modification adds taller CP_Radial_THT, following the dimensions of Nichicon UVZ series (https://www.nichicon.co.jp/english/products/pdfs/e-uvz.pdf).
It also probably reflects realistically many other brands and models.